### PR TITLE
Sunmin's data - ELS 2002 (data via e-mail)

### DIFF
--- a/Codebook_161007224535.txt
+++ b/Codebook_161007224535.txt
@@ -1,0 +1,8702 @@
+2012 Education Longitudinal Study of 2002 EDAT Extract Codebook
+
+C:\EDAT\ELS\Codebook_161007224535.txt
+
+/*****************************************************************************************
+NOTES:                                                                                  
+   (1) Full sample weights and/or replicate weights are added automatically.
+   (2) Identification numbers are added automatically.
+*****************************************************************************************/
+
+
+
+File:       BYF3PSTSTU.PRI
+Name:       STU_ID
+Position:   1
+Length:     6
+Label:      Student ID
+
+Description:
+Student ID is composed of the 4-digit School ID (which consists of
+the 3-digit stratum and 1-digit PSU) and a 2-digit sequential
+student code within school.
+Stratum (STRAT_ID) and PSU are embedded in STU_ID for ease of use
+in certain variance estimation programs.
+Note: The following reserve codes are used throughout the ECB. This
+description is added to the first variable of each section to help
+users understand the meaning of each reserve code.
+-1: "Don't know" represents respondents who indicated that they didn't
+know the answer to the question.
+-2: "Refused" represents respondents who indicated that they refused
+to answer the question
+-3: "Item legitimate skip/NA" is filled for questions that are not
+administered based on routing logic; i.e., the items are not
+applicable based on responses to prior questions.
+-4: "Nonrespondent" is filled for all variables across the entire
+questionnaire when a sample member did not respond to the
+questionnaire.
+-5: "Out of range" represents questionnaire respondents who
+reported values that are out of range.
+-6: "Multiple response" represents hard-copy questionnaire respondents
+who reported more than one response for an item that requires
+only one response.
+-7: "Partial interview-breakoff" is filled for questions that are not
+answered because the respondent does not wish to continue the
+interview or they have run out of time. This also includes particular
+items that are not included on an abbreviated-version questionnaire.
+-8: "Survey component legitimate skip/NA" is filled for all items
+within a survey component for sample members who were not administered
+that component by design for one of the following reasons:  1) the
+component was not administered based on their status (e.g., transfer
+students did not receive certain items on the in-school survey), 2)
+the sample member was not a part of the study at the time of
+administration (e.g., first follow-up freshened sample members were by
+definition not eligible for the base-year survey), or 3) the sample
+member was not capable of completing the survey component (e.g.,
+students who were questionnaire-ineligible due to a language barrier
+or disability at the time of the survey).
+-9: "Missing" is filled for questions that are not answered when the
+routing suggests that a response should have been provided.
+Source: ELS:2002 Sampling
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                       101101              461234           279542.71           104263.77 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       SCH_ID
+Position:   7
+Length:     4
+Label:      School ID
+
+Description:
+School ID provides linkage to school-level information. School ID
+includes the 3-digit stratum (STRAT_ID) variable and 1-digit PSU
+concatenated together. See descriptions of STRAT_ID and PSU.
+Source: ELS:2002 Sampling
+
+
+Variable suppressed with -5 values on the public use file.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       STRAT_ID
+Position:   11
+Length:     3
+Label:      Stratum
+
+Description:
+This variable is a component of the ELS:2002 school ID (first three
+digits). It indicates the analysis stratum to be used for computing
+Taylor Series variance estimates. The analysis strata were formed
+from the sampling strata used in the first stage of sampling. STRAT_ID
+is developed at the school level and replicated at the student level.
+This school level STRAT_ID should be used when generating school
+estimates. In order to support improved variance estimation, a
+larger number of strata (with fewer PSUs per stratum -- up to 3 PSUs
+per stratum) are used in ELS:2002, compared to NELS:88 or HS&B. See
+section 3.5 of the ELS:2002 Base Year Data File User's Manual.
+Source: ELS:2002 Sampling
+
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                          101                 461              279.37              104.26 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       PSU
+Position:   14
+Length:     2
+Label:      Primary sampling unit
+
+Description:
+This variable is a component of the ELS:2002 school ID (fourth
+digit). It indicates the analysis primary sampling unit (PSU, i.e.,
+School) to be used for computing Taylor Series variance estimates.
+PSU is developed at the school level and replicated at the student
+level. This school level PSU should be used when generating school
+estimates. In order to support improved variance estimation, a
+larger number of strata (with fewer PSUs per stratum -- up to 3 PSUs
+per stratum) are used in ELS:2002, compared to NELS:88 or HS&B.
+See section 3.5 of the ELS:2002 Base Year Data File User's Manual.
+Source: ELS:2002 Sampling
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1SCH_ID
+Position:   16
+Length:     4
+Label:      Link to first follow-up school
+
+Description:
+F1SCH_ID is an ID corresponding to the school in which the student
+is enrolled at the time of the first follow-up. F1SCH_ID values
+pertain to in-school students still attending their base-year
+school. F1SCH_ID values match SCH_ID values for base-year
+schools. New schools were assigned values from 9995
+to 9999. (See section 3.3 of the ELS:2002 Base-Year to First
+Follow-up Data File User's Manual for definition of "new schools.")
+F1SCH_ID is set to -8 for a student not attending a base-year or new
+school in the first follow-up.
+Source: ELS:2002 Sampling
+
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                         1011                9999             2824.54             1121.27 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1UNIV1
+Position:   20
+Length:     3
+Label:      Sample member status in BY and F1 rounds
+
+Description:
+Indicates simultaneously the base year and first follow-up
+status of sample members. This variable has valid values that
+account for every pattern encountered by ELS:2002 sample members.
+Value labels indicate BY status followed by F1 status.
+Definition of BY component within value label
+   BYR=Base Year Respondent
+   BYN=Base Year Nonrespondent
+   BYI=Base Year Questionnaire Ineligible (i.e., Expanded Sample only)
+   BNA=Base Year Not Applicable (i.e., Freshened 12th-grader in the
+       first follow-up)
+Definition of F1 component within value label
+   F1R=First Follow-up Respondent with the following trailing
+       characters meaning:
+       A=In-school, in grade
+       B=In-School out-of-grade
+       D=Dropout
+       F=Freshened
+       E=Received HS diploma early (on or before 3/15/2004)
+       G=Received GED/HS equivalent early (on or before 3/15/2004)
+       H=Homeschooled
+   F1NR=First Follow-up Nonrespondent
+   F1IE=First Follow-up Questionnaire Ineligible (i.e., Expanded
+        Sample only)
+   F1OD=First Follow-up Out of Scope (Deceased)
+   F1OS=First Follow-up Out of Scope (Other)
+For example, cases where F1UNIV1 = 101 relate to sample members with
+the following participation patterns:  "BYR F1RA" In other words,
+the sample members were BY respondents and F1 respondents
+in-School/in grade.
+Note: F1ESSTAT and F1NRSTAT are variables used below in the SAS code
+that are available only on the restricted use ECB. Their logic is
+applicable to sample members in the restricted use file only.
+SAS Code:
+  If F1UNIV2A in (3) then do; /* BYX */
+     If F1ESSTAT in (1,2)      then F1UNIV1=126; /* F1IE */
+     else If F1QSTAT in (1,2,3,4)
+          and G12COHRT=1            then F1UNIV1=120; /* F1RA */
+     else if F1QSTAT in (1,2,3,4)
+          and G12COHRT^=1           then F1UNIV1=123; /* F1RB */
+     else if F1QSTAT = 7            then F1UNIV1=121; /* F1RD */
+     else if F1QSTAT = 6
+          and F1EGQFLG=2            then F1UNIV1=122; /* F1RE */
+     else if F1QSTAT = 6
+          and F1EGQFLG=1            then F1UNIV1=124; /* F1RG */
+     else if F1QSTAT = 5            then F1UNIV1=125; /* F1RH */
+     end;
+  Else If F1UNIV2A in (4) then do; /* BNA */
+     If F1ESSTAT in (1,2)      then F1UNIV1=119; /* F1IE */
+     else if F1QSTAT in (4)         then F1UNIV1=118; /* F1RF */
+     end;
+  Else If F1UNIV2A in (2) then do; /* BYN */
+     If F1ESSTAT in (1,2)      then F1UNIV1=117; /* F1IE */
+     else If F1QSTAT in (1,2,3,4)
+          and G12COHRT=1            then F1UNIV1=111; /* F1RA */
+     else if F1QSTAT in (1,2,3,4)
+          and G12COHRT^=1            then F1UNIV1=114; /* F1RB */
+     else if F1QSTAT = 7            then F1UNIV1=112; /* F1RD */
+     else if F1QSTAT = 6
+          and F1EGQFLG=2            then F1UNIV1=113; /* F1RE */
+     else if F1QSTAT = 6
+          and F1EGQFLG=1            then F1UNIV1=115; /* F1RG */
+     else if F1QSTAT = 5            then F1UNIV1=116; /* F1RH */
+     end;
+ Else If F1UNIV2A in (1) then do;  /* BYR */
+     If F1NRSTAT = 4                then F1UNIV1=108; /* F1OD */
+     else If F1QSTAT = 0 then do;
+         If F1ESSTAT in (1,2)       then F1UNIV1=110; /* F1IE */
+         else If F1ENRFIN = 6       then F1UNIV1=109; /* F1OS */
+         else If F1QSTAT  = 0       then F1UNIV1=107; /* F1NR */
+     end;
+     else If F1QSTAT in (1,2,3,4)
+          and G12COHRT=1           then F1UNIV1=101; /* F1RA */
+     else if F1QSTAT in (1,2,3,4)
+          and G12COHRT^=1           then F1UNIV1=104; /* F1RB */
+     else if F1QSTAT = 7            then F1UNIV1=102; /* F1RD */
+     else if F1QSTAT = 6
+          and F1EGQFLG=2            then F1UNIV1=103; /* F1RE */
+     else if F1QSTAT = 6
+          and F1EGQFLG=1            then F1UNIV1=105; /* F1RG */
+     else if F1QSTAT = 5            then F1UNIV1=106; /* F1RH */
+     end;
+Source: ELS:2002 First follow-up Survey Control System
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+101                 BYR F1RA                                               12,601               77.80 
+102                 BYR F1RD                                                  609                3.76 
+103                 BYR F1RE                                                  393                2.43 
+104                 BYR F1RB                                                  241                1.49 
+105                 BYR F1RG                                                  123                0.76 
+106                 BYR F1RH                                                   39                0.24 
+107                 BYR F1NR                                                1,131                6.98 
+109                 BYR F1OS                                                   99                0.61 
+110                 BYR F1IE                                                    8                0.05 
+111                 BYN F1RA                                                  527                3.25 
+112                 BYN F1RD                                                   56                0.35 
+113                 BYN F1RE                                                   29                0.18 
+114                 BYN F1RB                                                   25                0.15 
+115                 BYN F1RG                                                   10                0.06 
+116                 BYN F1RH                                                    1                0.01 
+117                 BYN F1IE                                                    1                0.01 
+118                 BNA F1RF                                                  171                1.06 
+119                 BNA F1IE                                                    7                0.04 
+120                 BYI F1RA                                                   71                0.44 
+121                 BYI F1RD                                                   17                0.11 
+122                 BYI F1RE                                                    3                0.02 
+123                 BYI F1RB                                                   12                0.07 
+124                 BYI F1RG                                                    1                0.01 
+125                 BYI F1RH                                                    1                0.01 
+126                 BYI F1IE                                                   21                0.13 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1UNIV2A
+Position:   23
+Length:     2
+Label:      Base year status and how sample member entered F1 sample
+
+Description:
+Indicates the base year status (respondent, nonrespondent,
+questionnaire ineligible) for base year sample members; or that the
+sample member was included as part of the first follow-up 12th grade
+freshening.
+Source: ELS:2002 First follow-up Survey Control System
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Base year participant                                  15,244               94.12 
+2                   Base year nonparticipant                                  649                4.01 
+3                   Base year questionnaire ineligible                        126                0.78 
+4                   F1 Freshened sample member                                178                1.10 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1UNIV2B
+Position:   25
+Length:     2
+Label:      Sample member F1 status
+
+Description:
+Indicates first follow-up status of sample member (i.e., in school,
+in 12th grade; in school, not in 12th grade; dropout;
+homeschooled; early graduate; out of scope; F1 nonrespondent).
+SAS Code:
+  /* in school, in grade 12          */
+  if F1QSTAT in (1,2,3,4) and F1GRADE = 12  then F1UNIV2B = 1 ;
+  /* in school, out of grade 12      */
+  else if (F1QSTAT in (1,2,3,4)
+             and F1GRADE in (10, 11, 99) )  then F1UNIV2B = 2 ;
+  /* home schooled                   */
+  else if F1QSTAT  = 5                    then F1UNIV2B = 3 ;
+  /* Early Grad                         */
+  else if F1QSTAT  = 6                    then F1UNIV2B = 4 ;
+  /* dropout                      */
+  else if F1QSTAT  = 7                    then F1UNIV2B = 5 ;
+  /* out of scope (deceased; outside USA in this round) */
+  else if F1ENRFIN = 6                    then F1UNIV2B = 6 ;
+  /* Nonrespondent/F1 status unknown */
+  else                                         F1UNIV2B = 7 ;
+Source: ELS:2002 First follow-up Survey Control System
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   In school, in grade 12                                 13,370               82.55 
+2                   In school, out of grade 12                                278                1.72 
+3                   Homeschooled                                               41                0.25 
+4                   Early graduate                                            559                3.45 
+5                   Dropout                                                   682                4.21 
+6                   Out of scope                                               99                0.61 
+7                   Nonrespondent/F1 status unknown                         1,168                7.21 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F2UNIV1
+Position:   27
+Length:     3
+Label:      Sample member status in first 3 rounds
+
+Description:
+Indicates simultaneously the base year, first follow-up, and second
+follow-up status of each sample member. This variable has values that
+account for all possible status patterns of ELS:2002 sample members.
+Value labels indicate BY status, F1 status, and F2 status,
+respectively.
+Definition of BY component within value label:
+   BYR=Base Year Respondent
+   BYN=Base Year Nonrespondent
+   BYI=Base Year Questionnaire Ineligible (i.e., Expanded Sample only)
+   BNA=Base Year Not Applicable (i.e., Freshened 12th-grader in the
+       first follow-up)
+Definition of F1 component within value label:
+   F1R=First Follow-up Respondent
+   F1NR=First Follow-up Nonrespondent
+   F1IE=First Follow-up Questionnaire Ineligible (i.e., Expanded
+        Sample only)
+   F1OD=First Follow-up Out of Scope (Deceased)
+   F1OS=First Follow-up Out of Scope (Other)
+Definition of F2 component within value label:
+   F2R=Second Follow-up Respondent
+   F2NR=Second Follow-up Nonrespondent
+   F2OD= Second Follow-up Out of Scope (Deceased)
+   F2OS= Second Follow-up Out of Scope (Other)
+For example, cases where F2UNIV1=101 (BYR F1R F2R) relate to sample
+members who were respondents in the base year, first follow-up, and
+second follow-up surveys.
+SAS Code:
+If F1UNIV1 in (101,102,103,104,105,106) then do; /*BYR F1R*/
+   if F2NRSTAT=0 then F2UNIV1 = 101; /*BYR F1R F2R*/
+   else if F2NRSTAT IN(1,2,3) then F2UNIV1=102; /*BYR F1R F2NR*/
+   else if F2NRSTAT IN(4,5,6) then do;
+   	F2UNIV1=103; /*BYR F1R F2OS*/
+   end;
+end;
+else if F1UNIV1 in (107) then do; /*BYR F1NR*/
+if F2NRSTAT=0 then F2UNIV1 = 104; /*BYR F1NR F2R*/
+   else if F2NRSTAT IN(1,2,3) then F2UNIV1=105; /*BYR F1NR F2NR*/
+   else if F2NRSTAT IN(4,5,6) then do;
+        F2UNIV1=106;/*else F2UNIV1=108; /*BYR F1NR F2OS*/
+   end;
+end;
+else if F1UNIV1 in (109) then do; /*BYR F1OS*/
+    if F2NRSTAT=0 then F2UNIV1 = 107; /*BYR F1OS F2R*/
+        else if F2NRSTAT IN(1,2,3) then F2UNIV1=108; /*BYR F1OS F2NR*/
+        else if F2NRSTAT IN(4,5,6) then do;
+        F2UNIV1=109; /*BYR F1OS F2OS*/
+   end;
+end;
+else if F1UNIV1 in (110) then do; /*BYR F1IE*/
+	 if F2NRSTAT=0 then F2UNIV1 = 110; /*BYR F1IE F2R*/
+end;
+else if F1UNIV1 in (111, 112, 113, 114, 115, 116) then do; /*BYN F1R*/
+    if F2NRSTAT=0 then F2UNIV1 = 111; /*BYN F1R F2R*/
+        else if F2NRSTAT IN(1,2,3) then F2UNIV1=112; /*BYN F1R F2NR*/
+        else if F2NRSTAT IN(4,5,6) then do;
+        	F2UNIV1=113; /*BYN F1R F2OS*/
+   end;
+end;
+else if F1UNIV1 in (117) then do; /*BYN F1IE*/
+	 if F2NRSTAT=0 then F2UNIV1 = 114; /*BYN F1IE F2R*/
+end;
+else if F1UNIV1 in (118) then do; /*BNA F1R*/
+    if F2NRSTAT=0 then F2UNIV1 = 115; /*BNA F1R F2R*/
+        else if F2NRSTAT IN(1,2,3) then F2UNIV1=116; /*BNA F1R F2NR*/
+        else if F2NRSTAT IN(4,5,6) then do;
+        	F2UNIV1=117; /*BNA F1R F2OS*/
+   end;
+end;
+else if F1UNIV1 in (119) then do; /*BNA F1IE*/
+	 if F2NRSTAT=0 then F2UNIV1 = 118; /*BNA F1IE F2R*/
+end;
+else if F1UNIV1 in (120, 121, 122, 123, 124, 125) then do; /*BYI F1R*/
+    if F2NRSTAT=0 then F2UNIV1 = 119; /*BYI F1R F2R*/
+        else if F2NRSTAT IN(1,2,3) then F2UNIV1=120; /*BYI F1R F2NR*/
+        else if F2NRSTAT IN(4,5,6) then do;
+        	 F2UNIV1=121; /*BYI F1R F2OS*/
+   end;
+end;
+else if F1UNIV1 in (126) then do; /*BYI F1IE*/
+    if F2NRSTAT=0 then F2UNIV1 = 122; /*BYI F1IE F2R*/
+       else if F2NRSTAT IN(1,2,3) then F2UNIV1=123; /*BYI F1IE F2NR*/
+end;
+Applies to: All ELS:2002 sample members.
+Source: ELS:2002 Second follow-up Survey Control System
+
+
+Variable suppressed with -5 values on the public use file.
+
+                                                                        Frequency 
+Category            Label                                              Unweighted 
+------------------- ----------------------------------------- ------------------- 
+-5                  Suppressed                                             16,197 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F2UNIV_P
+Position:   30
+Length:     3
+Label:      Sample member status in first 3 rounds
+
+Description:
+Indicates simultaneously the base year, first follow-up, and second
+follow-up status of each sample member. This variable has values that
+account for all possible status patterns of ELS:2002 sample members.
+Value labels indicate BY status, F1 status, and F2 status,
+respectively.
+Definition of BY component within value label:
+   BYR=Base Year Respondent
+   BYN=Base Year Nonrespondent
+   BYI=Base Year Questionnaire Ineligible (i.e., Expanded Sample only)
+   BNA=Base Year Not Applicable (i.e., Freshened 12th-grader in the
+       first follow-up)
+Definition of F1 component within value label:
+   F1R=First Follow-up Respondent
+   F1NR=First Follow-up Nonrespondent
+   F1IE=First Follow-up Questionnaire Ineligible (i.e., Expanded
+        Sample only)
+   F1OD=First Follow-up Out of Scope (Deceased)
+   F1OS=First Follow-up Out of Scope (Other)
+Definition of F2 component within value label:
+   F2R=Second Follow-up Respondent
+   F2NR=Second Follow-up Nonrespondent
+   F2OD= Second Follow-up Out of Scope (Deceased)
+   F2OS= Second Follow-up Out of Scope (Other)
+For example, cases where F2UNIV1=101 (BYR F1R F2R) relate to sample
+members who were respondents in the base year, first follow-up, and
+second follow-up surveys.
+Note: F2UNIV_P is the public-use version of the restricted-use F2
+composite variable F2UNIV1. For disclosure avoidance purposes,
+F2UNIV_P combines all categories in F2UNIV1 with low cell counts ("BYR
+F1IE F2R", "BYN F1IE F2R", "BNA F1IE F2R", "BYI F1R F2OS", and "BYI
+F1IE F2NR") into a single "Other" category.
+SAS Code:
+If F1UNIV1 in (101,102,103,104,105,106) then do; /*BYR F1R*/
+   if F2NRSTAT=0 then F2UNIV1 = 101; /*BYR F1R F2R*/
+   else if F2NRSTAT IN(1,2,3) then F2UNIV1=102; /*BYR F1R F2NR*/
+   else if F2NRSTAT IN(4,5,6) then do;
+   	F2UNIV1=103; /*BYR F1R F2OS*/
+   end;
+end;
+else if F1UNIV1 in (107) then do; /*BYR F1NR*/
+if F2NRSTAT=0 then F2UNIV1 = 104; /*BYR F1NR F2R*/
+   else if F2NRSTAT IN(1,2,3) then F2UNIV1=105; /*BYR F1NR F2NR*/
+   else if F2NRSTAT IN(4,5,6) then do;
+        F2UNIV1=106;/*else F2UNIV1=108; /*BYR F1NR F2OS*/
+   end;
+end;
+else if F1UNIV1 in (109) then do; /*BYR F1OS*/
+    if F2NRSTAT=0 then F2UNIV1 = 107; /*BYR F1OS F2R*/
+        else if F2NRSTAT IN(1,2,3) then F2UNIV1=108; /*BYR F1OS F2NR*/
+        else if F2NRSTAT IN(4,5,6) then do;
+        F2UNIV1=109; /*BYR F1OS F2OS*/
+   end;
+end;
+else if F1UNIV1 in (110) then do; /*BYR F1IE*/
+	 if F2NRSTAT=0 then F2UNIV1 = 110; /*BYR F1IE F2R*/
+end;
+else if F1UNIV1 in (111, 112, 113, 114, 115, 116) then do; /*BYN F1R*/
+    if F2NRSTAT=0 then F2UNIV1 = 111; /*BYN F1R F2R*/
+        else if F2NRSTAT IN(1,2,3) then F2UNIV1=112; /*BYN F1R F2NR*/
+        else if F2NRSTAT IN(4,5,6) then do;
+        	F2UNIV1=113; /*BYN F1R F2OS*/
+   end;
+end;
+else if F1UNIV1 in (117) then do; /*BYN F1IE*/
+	 if F2NRSTAT=0 then F2UNIV1 = 114; /*BYN F1IE F2R*/
+end;
+else if F1UNIV1 in (118) then do; /*BNA F1R*/
+    if F2NRSTAT=0 then F2UNIV1 = 115; /*BNA F1R F2R*/
+        else if F2NRSTAT IN(1,2,3) then F2UNIV1=116; /*BNA F1R F2NR*/
+        else if F2NRSTAT IN(4,5,6) then do;
+        	F2UNIV1=117; /*BNA F1R F2OS*/
+   end;
+end;
+else if F1UNIV1 in (119) then do; /*BNA F1IE*/
+	 if F2NRSTAT=0 then F2UNIV1 = 118; /*BNA F1IE F2R*/
+end;
+else if F1UNIV1 in (120, 121, 122, 123, 124, 125) then do; /*BYI F1R*/
+    if F2NRSTAT=0 then F2UNIV1 = 119; /*BYI F1R F2R*/
+        else if F2NRSTAT IN(1,2,3) then F2UNIV1=120; /*BYI F1R F2NR*/
+        else if F2NRSTAT IN(4,5,6) then do;
+        	 F2UNIV1=121; /*BYI F1R F2OS*/
+   end;
+end;
+else if F1UNIV1 in (126) then do; /*BYI F1IE*/
+    if F2NRSTAT=0 then F2UNIV1 = 122; /*BYI F1IE F2R*/
+       else if F2NRSTAT IN(1,2,3) then F2UNIV1=123; /*BYI F1IE F2NR*/
+end;
+/* Build public-use composite */
+If F2UNIV1 IN(110,114,118,121,123) Then F2UNIV_P = 999;
+   Else F2UNIV_P = F2UNIV1;
+Applies to: All ELS:2002 sample members.
+Source: ELS:2002 Second follow-up Survey Control System
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+101                 BYR F1R F2R                                            12,591               77.74 
+102                 BYR F1R F2NR                                            1,156                7.14 
+103                 BYR F1R F2OS                                              259                1.60 
+104                 BYR F1NR F2R                                              751                4.64 
+105                 BYR F1NR F2NR                                             347                2.14 
+106                 BYR F1NR F2OS                                              33                0.20 
+107                 BYR F1OS F2R                                               40                0.25 
+108                 BYR F1OS F2NR                                              35                0.22 
+109                 BYR F1OS F2OS                                              24                0.15 
+111                 BYN F1R F2R                                               521                3.22 
+112                 BYN F1R F2NR                                              111                0.69 
+113                 BYN F1R F2OS                                               16                0.10 
+115                 BNA F1R F2R                                               128                0.79 
+116                 BNA F1R F2NR                                               24                0.15 
+117                 BNA F1R F2OS                                               19                0.12 
+119                 BYI F1R F2R                                                81                0.50 
+120                 BYI F1R F2NR                                               16                0.10 
+122                 BYI F1IE F2R                                               19                0.12 
+999                 Other                                                      26                0.16 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3UNIV
+Position:   33
+Length:     4
+Label:      Cross-round sample member status summary (BY to F3)
+
+Description:
+Indicates simultaneously the base year, first follow-up, second follow-up, and third follow-up response status of each sample member. This variable has values that account for all possible binary response status patterns (respondent vs. nonrespondent) of ELS:2002 sample members across all rounds.
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0000                BYNR, F1NR, F2NR, F3NR                                      2                0.01 
+0010                BYNR, F1NR, F2R, F3NR                                      11                0.07 
+0011                BYNR, F1NR, F2R, F3R                                       16                0.10 
+0100                BYNR, F1R, F2NR, F3NR                                     102                0.63 
+0101                BYNR, F1R, F2NR, F3R                                       92                0.57 
+0110                BYNR, F1R, F2R, F3NR                                      117                0.72 
+0111                BYNR, F1R, F2R, F3R                                       613                3.78 
+1000                BYR, F1NR, F2NR, F3NR                                     237                1.46 
+1001                BYR, F1NR, F2NR, F3R                                      202                1.25 
+1010                BYR, F1NR, F2R, F3NR                                      188                1.16 
+1011                BYR, F1NR, F2R, F3R                                       611                3.77 
+1100                BYR, F1R, F2NR, F3NR                                      594                3.67 
+1101                BYR, F1R, F2NR, F3R                                       821                5.07 
+1110                BYR, F1R, F2R, F3NR                                     1,696               10.47 
+1111                BYR, F1R, F2R, F3R                                     10,895               67.27 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3UNIVG10
+Position:   37
+Length:     5
+Label:      Cross-round sample member status summary (BY to F3) specific to 10th grade cohort
+
+Description:
+Indicates simultaneously the base year, first follow-up, second follow-up and third follow-up response status of sample members belonging to the 10th grade cohort. The high school transcript population is also represented. This variable has values that account for all possible binary response status patterns (respondent vs. nonrespondent) of ELS:2002 sample members across all rounds. It should be noted that a designation of nonrespondent in the context of this variable represents all varieties of nonresponse including sample members that were out of the country, incapacitated, institutionalized, refused, could not be located or were otherwise out-of-scope.
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+00000               Not a 10th grade cohort member                            178                1.10 
+10000               G10, BYNR, F1NR, F2NR, F3NR                                 2                0.01 
+10010               G10, BYNR, F1NR, F2R, F3NR                                  6                0.04 
+10011               G10, BYNR, F1NR, F2R, F3R                                  14                0.09 
+10100               G10, BYNR, F1R, F2NR, F3NR                                 74                0.46 
+10101               G10, BYNR, F1R, F2NR, F3R                                  77                0.48 
+10110               G10, BYNR, F1R, F2R, F3NR                                  89                0.55 
+10111               G10, BYNR, F1R, F2R, F3R                                  513                3.17 
+11000               G10, BYR, F1NR, F2NR, F3NR                                237                1.46 
+11001               G10, BYR, F1NR, F2NR, F3R                                 202                1.25 
+11010               G10, BYR, F1NR, F2R, F3NR                                 188                1.16 
+11011               G10, BYR, F1NR, F2R, F3R                                  611                3.77 
+11100               G10, BYR, F1R, F2NR, F3NR                                 594                3.67 
+11101               G10, BYR, F1R, F2NR, F3R                                  821                5.07 
+11110               G10, BYR, F1R, F2R, F3NR                                1,696               10.47 
+11111               G10, BYR, F1R, F2R, F3R                                10,895               67.27 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3UNIVG12
+Position:   42
+Length:     5
+Label:      Cross-round sample member status summary (BY to F3) specific to 12th grade cohort
+
+Description:
+Indicates simultaneously the base year, first follow-up, second follow-up and third follow-up response status of sample members belonging to the 12th grade cohort. The high school transcript population is also represented. This variable has values that account for all possible binary response status patterns (respondent vs. nonrespondent) of ELS:2002 sample members across all rounds. It should be noted that a designation of nonrespondent in the context of this variable represents all varieties of nonresponse including sample members that were out of the country, incapacitated, institutionalized, refused, could not be located or were otherwise out-of-scope.
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+00000               Not a 12th grade cohort member                          2,182               13.47 
+10000               G12, BYNR, F1NR, F2NR, F3NR                                 1                0.01 
+10010               G12, BYNR, F1NR, F2R, F3NR                                  9                0.06 
+10011               G12, BYNR, F1NR, F2R, F3R                                  11                0.07 
+10100               G12, BYNR, F1R, F2NR, F3NR                                 85                0.52 
+10101               G12, BYNR, F1R, F2NR, F3R                                  76                0.47 
+10110               G12, BYNR, F1R, F2R, F3NR                                  95                0.59 
+10111               G12, BYNR, F1R, F2R, F3R                                  513                3.17 
+11000               G12, BYR, F1NR, F2NR, F3NR                                 46                0.28 
+11001               G12, BYR, F1NR, F2NR, F3R                                  56                0.35 
+11010               G12, BYR, F1NR, F2R, F3NR                                 104                0.64 
+11011               G12, BYR, F1NR, F2R, F3R                                  418                2.58 
+11100               G12, BYR, F1R, F2NR, F3NR                                 520                3.21 
+11101               G12, BYR, F1R, F2NR, F3R                                  705                4.35 
+11110               G12, BYR, F1R, F2R, F3NR                                1,499                9.25 
+11111               G12, BYR, F1R, F2R, F3R                                 9,877               60.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       G10COHRT
+Position:   47
+Length:     2
+Label:      Sophomore cohort member in 2001-2002 school year
+
+Description:
+Sophomore cohort member, i.e., spring 2002 10th-grader. Use
+G10COHRT in concert with the BYSTUWT weight to get a nationally
+representative, cross-sectional population of the 2002 spring
+term sophomore class. If the respondent was not in the freshened
+student sample, then G10COHRT is set to 1.
+SAS Code:
+if F1UNIV2A in (1, 2, 3) then G10COHRT = 1 ;
+else G10COHRT = 0 ;
+Source: ELS:2002 First follow-up Survey Control System
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   Not sophomore cohort member                               178                1.10 
+1                   Sophomore cohort member                                16,019               98.90 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       G12COHRT
+Position:   49
+Length:     2
+Label:      Spring 2004 senior cohort member
+
+Description:
+This variable indicates whether the sample member is a Senior cohort
+member, i.e., a spring 2004 12th-grader. F1-identified senior
+cohort members include F1 respondents at base year schools, as well as
+those who transferred, if they indicated they were 12th-graders.
+Spring 2004 grade was imputed where missing for F1 respondents (see
+also F1GRADE/F2F1GRDE). G12COHRT has also been updated since the
+first follow-up version to identify F1 nonrespondents whose second
+follow-up or transcript information indicates they were in fact spring
+2004 12th-graders. Values of 2 also include freshened cases who
+were F1 questionnaire-ineligible.
+Use G12COHRT in concert with F1, transcript, or F2 weights to get an
+appropriately weighted sample that generalizes to the 2004 spring term
+senior class. For example, G12COHRT=1 used with F1QWT generates
+estimates for a nationally representative, cross-sectional population
+of the 2004 spring term senior class. G12CHORT>0 used with F2F1WT
+generates estimates for a nationally representative panel of the
+spring term senior class, including F1 nonrespondents.
+SAS Code:
+If G12COHRT = 0 And F1NRSTAT > 0 Then Do;
+   If F2F1GRDE=12 Then G12COHRT=2;
+End;
+Applies to: All ELS:2002 sample members.
+Source: ELS:2002 First follow-up Student and Transfer Questionnaires;
+ELS:2002 first follow-up Survey Control System; Imputation; High
+School Transcript; ELS:2002 Second follow-up interview
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   Not senior cohort member                                2,182               13.47 
+1                   F1 identified senior cohort member                     13,370               82.55 
+2                   F2/trnscrpt identified sr cohort member                   645                3.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       BYSTUWT
+Position:   51
+Length:     10
+Label:      Base year student weight
+
+Description:
+Student final weight for all base year responding students. See
+section 3.4.2 of the ELS:2002 Base Year Data File User's Manual.
+Note: The following reserve codes are used throughout the ECB. This
+description is added to the first variable of each section to help
+users understand the meaning of each reserve code.
+-1: "Don't know" represents respondents who indicated that they didn't
+know the answer to the question.
+-2: "Refused" represents respondents who indicated that they refused
+to answer the question
+-3: "Item legitimate skip/NA" is filled for questions that are not
+administered based on routing logic; i.e., the items are not
+applicable based on responses to prior questions.
+-4: "Nonrespondent" is filled for all variables across the entire
+questionnaire when a sample member did not respond to the
+questionnaire.
+-5: "Out of range" represents questionnaire respondents who
+reported values that are out of range.
+-6: "Multiple response" represents hard copy questionnaire respondents
+who reported more than one response for an item that requires
+only one response.
+-7: "Partial interview-breakoff" is filled for questions that are not
+answered because the respondent does not wish to continue the
+interview or they have run out of time. This also includes particular
+items that are not included on an abbreviated version questionnaire.
+-8: "Survey component legitimate skip/NA" is filled for all items
+within a survey component for sample members who were not administered
+that component by design for one of the following reasons:  1) the
+component was not administered based on their status (e.g., transfer
+students did not receive certain items on the in-school survey), 2)
+the sample member was not a part of the study at the time of
+administration (e.g., first follow-up freshened sample members were by
+definition not eligible for the base-year survey), or 3) the sample
+member was not capable of completing the survey component (e.g.,
+students who were questionnaire-ineligible due to a language barrier
+or disability at the time of the survey).
+-9: "Missing" is filled for questions that are not answered when the
+routing suggests that a response should have been provided.
+Source: ELS:2002 Weighting
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       BYEXPWT
+Position:   61
+Length:     10
+Label:      Student expanded sample weight (restricted)
+
+Description:
+Student final weight for the expanded sample of questionnaire-eligible
+and questionnaire-ineligible students. Questionnaire-ineligible
+students were excused from completion of the questionnaire or the
+test when (for reasons of their lack of proficiency in English or
+severe disabilities) they could not validly be assessed or complete a
+questionnaire, or could only be surveyed under conditions that would
+be unduly arduous or uncomfortable for them. This weight can be used
+for analyses including the base year expanded sample.
+See section 3.4.2 of the ELS:2002 Base Year Data File User's Manual.
+Source: ELS:2002 Weighting
+
+
+Variable suppressed with -5 values on the public use file.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1QWT
+Position:   599
+Length:     10
+Label:      First follow-up questionnaire (cross-sectional) weight
+
+Description:
+This weight applies to all first follow-up respondents, regardless
+of their participation status in the base year. When used with the
+appropriate sample flags (selection criteria appear in parentheses
+below), it allows projections to the following populations:
+     -Spring 2002 10th-graders capable of completing questionnaires
+     in 2004, regardless of 2002 participation (G10COHRT=1)
+          or
+     -Spring 2004 12th-graders capable of completing questionnaires
+     in 2004 regardless of 2002 participation (G12COHRT=1).
+For additional information, see section 3.4 in the ELS:2002
+Base Year to First Follow-Up Data File Use's Manual.
+Note: The following reserve codes are used throughout the ECB. This
+description is added to the first variable of each section to help
+users understand the meaning of each reserve code.
+-1: "Don't know" represents respondents who indicated that they didn't
+know the answer to the question.
+-2: "Refused" represents respondents who indicated that they refused
+to answer the question
+-3: "Item legitimate skip/NA" is filled for questions that are not
+administered based on routing logic; i.e., the items are not
+applicable based on responses to prior questions.
+-4: "Nonrespondent" is filled for all variables across the entire
+questionnaire when a sample member did not respond to the
+questionnaire.
+-5: "Out of range" represents questionnaire respondents who
+reported values that are out of range.
+-6: "Multiple response" represents hard copy questionnaire respondents
+who reported more than one response for an item that requires
+only one response.
+-7: "Partial interview-breakoff" is filled for questions that are not
+answered because the respondent does not wish to continue the
+interview or they have run out of time. This also includes particular
+items that are not included on an abbreviated version questionnaire.
+-8: "Survey component legitimate skip/NA" is filled for all items
+within a survey component for sample members who were not administered
+that component by design for one of the following reasons:  1) the
+component was not administered based on their status (e.g., transfer
+students did not receive certain items on the in-school survey), 2)
+the sample member was not a part of the study at the time of
+administration (e.g., first follow-up freshened sample members were by
+definition not eligible for the base-year survey), or 3) the sample
+member was not capable of completing the survey component (e.g.,
+students who were questionnaire-ineligible due to a language barrier
+or disability at the time of the survey).
+-9: "Missing" is filled for questions that are not answered when the
+routing suggests that a response should have been provided.
+Source: ELS:2002 First follow-up Weighting
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1PNLWT
+Position:   609
+Length:     10
+Label:      Panel Weight, BY and F1 (2002 and 2004)
+
+Description:
+This panel weight applies to sample members who were respondents in
+both the ELS:2002 base year (2002) and first follow-up (2004) surveys
+or who were respondents in the first follow-up only but have imputed
+base year data. This weight can be used when comparing base year data
+with first follow-up data for the population of questionnaire-eligible
+spring 2002 10th-graders. For additional information, see
+section 3.4 of the ELS:2002 Base Year to First Follow-Up Data File
+Users Manual.
+Source: ELS:2002 First follow-up Weighting
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1EXPWT
+Position:   619
+Length:     10
+Label:      F1 expanded sample weight (restricted)
+
+Description:
+This weight applies to sample members who are in the first follow-up
+expanded sample. The first follow-up expanded sample includes
+questionnaire-capable respondents and questionnaire-incapable sample
+members. Questionnaire-incapable sample members were excused from
+completion of the questionnaire or the test when (for reasons of
+their lack of proficiency in English or severe disabilities) they
+could not validly be assessed or complete a questionnaire, or could
+only be surveyed under conditions that would be unduly arduous or
+uncomfortable for them. When used with the appropriate sample
+flags (selection criteria appear in parentheses below), it allows
+projections to the following populations:
+     -Spring 2002 10th-graders, regardless of 2002 participation
+     (G10COHRT=1)
+          or
+     -Spring 2004 12th-graders, regardless of 2002 participation
+     (G12COHRT=1).
+For additional information, see section 3.4 of the ELS:2002
+Base Year to First Follow-Up Data File User's Manual.
+Available only on the restricted-use file.
+Source: ELS:2002 First follow-up Weighting
+
+
+Variable suppressed with -5 values on the public use file.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1XPNLWT
+Position:   629
+Length:     10
+Label:      F1 expanded sample panel weight (restricted)
+
+Description:
+This panel weight applies to expanded sample members who were
+respondents in both rounds of ELS:2002, those who were only
+respondents in the first follow-up but have base year data imputed,
+or those who were incapable of completing the questionnaire in the
+base year and/or first follow-up. This weight can be used when
+comparing base year data with first follow-up data for the
+population of questionnaire-eligible and questionnaire-ineligible
+spring 2002 10th-graders.
+For additional information, see section 3.4 of the ELS:2002
+Base Year to First Follow-Up Data File User's Manual.
+Available only on the restricted-use file.
+Source: ELS:2002 First follow-up Weighting
+
+
+Variable suppressed with -5 values on the public use file.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1TRSCWT
+Position:   952
+Length:     10
+Label:      Cross-sectional high school transcript weight
+
+Description:
+This cross-sectional weight applies to all sample members for whom at
+least one transcript with at least one course record on it was
+received. This includes students who only participated in the base-
+year, those who only participated in the first follow-up, and those
+who participated in both the base-year and first follow-up. This
+weight also includes both questionnaire-eligible and questionnaire-
+ineligible sample members. When used with the appropriate sample
+flags (selection criteria appear in parentheses below), it allows
+projections to the following populations:
+     -Spring 2002 10th-graders (G10COHRT=1)
+          or
+     -Spring 2004 12th-graders (G12COHRT=1).
+For additional information, see the ELS:2002 Data File Documentation
+Applies to: All high school transcript respondents.
+Source: High School Transcript
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F2QTSCWT
+Position:   1968
+Length:     10
+Label:      Second follow-up transcript cross-sectional weight
+
+Description:
+This cross-sectional weight applies to all sample members for whom at
+least one transcript with at least one course record was received, and
+who participated in the second follow-up. When used with the
+appropriate sample flags (selection criteria appear in parentheses
+below), it allows projections to the following populations:
+     -Spring 2002 10th-graders (G10COHRT=1)
+          or
+     -Spring 2004 12th-graders (G12COHRT=1 or 2).
+For additional information, see the ELS:2002 Data File Documentation.
+Source: ELS:2002 Second follow-up Weighting
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F2QWT
+Position:   1978
+Length:     10
+Label:      Second follow-up cross-sectional weight
+
+Description:
+This weight applies to all second follow-up respondents. When used
+with the appropriate sample flags (selection criteria appear in
+parentheses below), it allows projections to the following
+populations:
+     -Spring 2002 10th-graders (G10COHRT=1)
+          or
+     -Spring 2004 12th-graders (G12COHRT=1 or 2).
+For additional information, see the ELS:2002 Data File Documentation.
+Source: ELS:2002 Second follow-up Weighting
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F2F1WT
+Position:   1988
+Length:     10
+Label:      Second follow-up first follow-up panel weight
+
+Description:
+This weight applies to all sample members who responded in the first
+follow-up and the second follow-up. When used with the appropriate
+sample flags (selection criteria appear in parentheses below), it
+allows projections to the following populations:
+     -Spring 2002 10th-graders (G10COHRT=1)
+          or
+     -Spring 2004 12th-graders (G12COHRT=1 or 2).
+For additional information, see the ELS:2002 Data File Documentation.
+Source: ELS:2002 Second follow-up Weighting
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F2BYWT
+Position:   1998
+Length:     10
+Label:      Second follow-up base year panel weight
+
+Description:
+This weight applies to all sample members who responded in the base
+year and the second follow-up. This weight allows projections to the
+following population:
+     -Spring 2002 10th-graders
+For additional information, see the ELS:2002 Data File Documentation.
+Source: ELS:2002 Second follow-up Weighting
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3QWT
+Position:   2791
+Length:     10
+Label:      Third follow-up questionnaire respondent weight
+
+Description:
+A weight for sample members who completed a questionnaire in the third follow-up.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3BYPNLWT
+Position:   2801
+Length:     10
+Label:      Panel weight, BY and F3 (2002 and 2012)
+
+Description:
+A panel weight for all sample members who completed a questionnaire in the base year and third follow-up.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3F1PNLWT
+Position:   2811
+Length:     10
+Label:      Panel weight, F1 and F3 (2006 and 2012)
+
+Description:
+A panel weight for all sample members who completed a questionnaire in the first follow-up and third follow-up.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3QTSCWT
+Position:   2821
+Length:     10
+Label:      Third follow-up HS transcript respondent weight
+
+Description:
+A weight for all sample members who completed a questionnaire in the third follow-up and for whom high school transcript data have been collected.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3BYTSCWT
+Position:   2831
+Length:     10
+Label:      Panel weight, BY and F3 (2002 and 2012) HS transcript respondent weight
+
+Description:
+A panel weight for all sample members who completed a questionnaire in the base year and the third follow-up and for whom high school transcript data have been collected.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3F1TSCWT
+Position:   2841
+Length:     10
+Label:      Panel weight, F1 and F3 (2006 and 2012) HS transcript respondent weight
+
+Description:
+A panel weight for all sample members who completed a questionnaire in the first follow-up and the third follow-up and for whom high school transcript data have been collected.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3QTSCWT_O
+Position:   3227
+Length:     10
+Label:      Third follow-up HS transcript respondent weight (superseded by F3QTSCWT)
+
+Description:
+A weight for all sample members who completed a questionnaire in the third follow-up and for whom high postsecondary institution transcript data have been collected. (superseded by F3QTSCWT) This weight has been superseded by F3QTSCWT and is included in the postsecondary transcript (PETS) data release as a means of preserving the original values. It is one of three ELS:2002 third follow-up high postsecondary institution weights (F3QTSCWT_O, F3BYTSCWT_O, and F3F1TSCWT_O) constructed only for those sample members for whom a high postsecondary institution transcript was collected from their base year high postsecondary institution, and since superseded. The superseding versions (F3QTSCWT, F3BYTSCWT, and F3F1TSCWT respectively) were constructed in order to incorporate the approximately 230 sample members for whom high postsecondary institution transcripts were collected from transfer postsecondary  institutions but not collected from their base year high postsecondary  institutions. For additional information on this variable, please see chapter 5 of the ELS postsecondary transcript DFD.
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3BYTSCWT_O
+Position:   3237
+Length:     10
+Label:      Panel weight, BY and F3 (2002 and 2012) HS transcript respondent weight (superseded by F3BYTSCWT)
+
+Description:
+A panel weight for all sample members who completed a questionnaire in the base year and the third follow-up and for whom high postsecondary institution transcript data have been collected. (superseded by F3BYTSCWT)  This weight has been superseded by F3BYTSCWT and is included in the postsecondary transcript (PETS) data release as a means of preserving the original values. It is one of three ELS:2002 third follow-up high postsecondary institution weights (F3QTSCWT_O, F3BYTSCWT_O, and F3F1TSCWT_O) constructed only for those sample members for whom a high postsecondary institution transcript was collected from their base year high postsecondary institution, and since superseded. The superseding versions (F3QTSCWT, F3BYTSCWT, and F3F1TSCWT respectively) were constructed in order to incorporate the approximately 230 sample members for whom high postsecondary institution transcripts were collected from transfer postsecondary  institutions but not collected from their base year high postsecondary  institutions. For additional information on this variable, please see chapter 5 of the ELS postsecondary transcript DFD.
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3F1TSCWT_O
+Position:   3247
+Length:     10
+Label:      Panel weight, F1 and F3 (2006 and 2012) HS transcript respondent weight (superseded by F3F1TSCWT)
+
+Description:
+A panel weight for all sample members who completed a questionnaire in the first follow-up and the third follow-up and for whom high postsecondary institution transcript data have been collected. (superseded by F3F1TSCWT)  This weight has been superseded by F3F1TSCWT and is included in the postsecondary transcript (PETS) data release as a means of preserving the original values. It is one of three ELS:2002 third follow-up high postsecondary institution weights (F3QTSCWT_O, F3BYTSCWT_O, and F3F1TSCWT_O) constructed only for those sample members for whom a high postsecondary institution transcript was collected from their base year high postsecondary institution, and since superseded. The superseding versions (F3QTSCWT, F3BYTSCWT, and F3F1TSCWT respectively) were constructed in order to incorporate the approximately 230 sample members for whom high postsecondary institution transcripts were collected from transfer postsecondary  institutions but not collected from their base year high postsecondary  institutions. For additional information on this variable, please see chapter 5 of the ELS postsecondary transcript DFD.
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       PSWT
+Position:   3628
+Length:     10
+Label:      Transcript: Postsecondary transcript respondent weight
+
+Description:
+A weight for sample members for whom postsecondary transcript data have been collected.
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3BYPNLPSWT
+Position:   3638
+Length:     10
+Label:      Transcript: Panel weight, BY, F3, and postsecondary transcript
+
+Description:
+A panel weight for all sample members who completed a questionnaire in the base year and the third follow-up and for whom postsecondary transcript data have been collected.
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3BYTSCPSWT
+Position:   3648
+Length:     10
+Label:      Transcript: Panel weight, BY, F3, high school transcript, and postsecondary transcript
+
+Description:
+A panel weight for all sample members who completed a questionnaire in the base year and the third follow-up and for whom high postsecondary institution and postsecondary transcript data have been collected.
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3F1PNLPSWT
+Position:   3658
+Length:     10
+Label:      Transcript: Panel weight, F1, F3, and postsecondary transcript
+
+Description:
+A panel weight for all sample members who completed a questionnaire in the first follow-up and third follow-up and for whom postsecondary transcript data have been collected.
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3F1TSCPSWT
+Position:   3668
+Length:     10
+Label:      Transcript: Panel weight, F1, F3, high school transcript, and postsecondary transcript
+
+Description:
+A panel weight for all sample members who completed a questionnaire in the first follow-up and third follow-up and for whom high postsecondary institution and postsecondary transcript data have been collected.
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3QPSWT
+Position:   3678
+Length:     10
+Label:      Transcript: Panel weight, F3, and postsecondary transcript
+
+Description:
+A panel weight for all sample members who completed a questionnaire in the third follow-up and for whom postsecondary transcript data have been collected.
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F3QTSCPSWT
+Position:   3688
+Length:     10
+Label:      Transcript: Panel weight, F3, high school transcript, and postsecondary transcript
+
+Description:
+A panel weight for all sample members who completed a questionnaire in the third follow-up and for whom high postsecondary institution and postsecondary transcript data have been collected.
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       PSTSCWT
+Position:   3698
+Length:     10
+Label:      Transcript: Panel weight, high school transcript, and postsecondary transcript
+
+Description:
+A panel weight for all sample members for whom high postsecondary institution and postsecondary transcript data have been collected.
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D19
+Position:   6646
+Length:     6
+Label:      Month and year last attended school (DO)
+
+Description:
+   19. When did you last attend high school?
+   Month
+   January
+   February
+   March
+   April
+   May
+   June
+   July
+   August
+   September
+   October
+   November
+   December
+   Year
+   2002
+   2003
+   2004
+Note:   This item also appears on the early graduate (F1E20)
+questionnaire, which is identical. However, the variable F1D19
+contains only data collected from dropouts. Data provided in a single
+(yyyymm) format.
+Note: The following reserve codes are used throughout the ECB. This
+description is added to the first variable of each section to help
+users understand the meaning of each reserve code.
+-1: "Don't know" represents respondents who indicated that they didn't
+know the answer to the question.
+-2: "Refused" represents respondents who indicated that they refused
+to answer the question
+-3: "Item legitimate skip/NA" is filled for questions that are not
+administered based on routing logic; i.e., the items are not
+applicable based on responses to prior questions.
+-4: "Nonrespondent" is filled for all variables across the entire
+questionnaire when a sample member did not respond to the
+questionnaire.
+-5: "Out of range" represents questionnaire respondents who
+reported values that are out of range.
+-6: "Multiple response" represents hard copy questionnaire respondents
+who reported more than one response for an item that requires
+only one response.
+-7: "Partial interview-breakoff" is filled for questions that are not
+answered because the respondent does not wish to continue the
+interview or they have run out of time. This also includes particular
+items that are not included on an abbreviated version questionnaire.
+-8: "Survey component legitimate skip/NA" is filled for all items
+within a survey component for sample members who were not administered
+that component by design for one of the following reasons:  1) the
+component was not administered based on their status (e.g., transfer
+students did not receive certain items on the in-school survey), 2)
+the sample member was not a part of the study at the time of
+administration (e.g., first follow-up freshened sample members were by
+definition not eligible for the base-year survey), or 3) the sample
+member was not capable of completing the survey component (e.g.,
+students who were questionnaire-ineligible due to a language barrier
+or disability at the time of the survey).
+-9: "Missing" is filled for questions that are not answered when the
+routing suggests that a response should have been provided.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                    200200.00           200403.00           200292.23               65.34 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D20
+Position:   6652
+Length:     2
+Label:      Grade when last attended school (DO)
+
+Description:
+   20. What grade were you in then?
+   (MARK ONE RESPONSE)
+   10th grade (GO TO QUESTION 21)
+   11th grade (GO TO QUESTION 21)
+   12th grade (GO TO QUESTION 21)
+   No grade system used (SKIP TO QUESTION 22 ON PAGE 7)
+Note:   This item also appears on the early graduate (F1E21)
+questionnaire, which is identical. However, the variable F1D20
+contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   10th grade                                                140                0.86 
+2                   11th grade                                                317                1.96 
+3                   12th grade                                                200                1.23 
+4                   No grade system used                                        7                0.04 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-6                  Multiple response                                           2                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                 15                0.09 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D21
+Position:   6654
+Length:     2
+Label:      Whether passed last grade attended
+
+Description:
+   21. Did you pass that grade?
+   Yes
+   No
+Note:   This item only appears on the dropout questionnaire.
+Applies to: Respondents whose school has a grade system.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        504                3.11 
+1                   Yes                                                       132                0.82 
+-9                  Missing                                                     9                0.06 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                     7                0.04 
+-1                  Don't know                                                 30                0.19 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D22
+Position:   6656
+Length:     2
+Label:      Left school for more than a month before last left
+
+Description:
+   22. Before you last left school, did you ever leave school for
+   more than a month for a reason other than illness or summer
+   vacation?
+   Yes (GO TO QUESTION 23)
+   No (SKIP TO QUESTION 25 ON PAGE 8)
+Note:   This item only appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        569                3.51 
+1                   Yes                                                       108                0.67 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D23
+Position:   6658
+Length:     6
+Label:      Month and year first left school for more than a month
+
+Description:
+   23. When was the very first time you left school for more than a
+   month?
+   Month
+   January
+   February
+   March
+   April
+   May
+   June
+   July
+   August
+   September
+   October
+   November
+   December
+   Year
+   1999 or before
+   2000
+   2001
+   2002
+   2003
+   2004
+Note:   This item only appears on the dropout questionnaire. Data
+provided in a single (yyyymm) format.
+Applies to: Respondents who left school for more than a month before
+last left.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                    199901.00           200403.00           200225.24              113.39 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D24
+Position:   6664
+Length:     6
+Label:      Month and year returned to school
+
+Description:
+   24. When did you return to school?
+   Month
+   January
+   February
+   March
+   April
+   May
+   June
+   July
+   August
+   September
+   October
+   November
+   December
+   Year
+   1999 or before
+   2000
+   2001
+   2002
+   2003
+   2004
+Note:   This item only appears on the dropout questionnaire. Data
+provided in a single (yyyymm) format.
+Applies to: Respondents who left school for more than a month before
+last left.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                    200005.00           200402.00           200256.38              101.52 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D25
+Position:   6670
+Length:     2
+Label:      Attended school during 2002-2003 school year
+
+Description:
+   25. Did you attend high school during the 2002-2003 school year?
+   Yes (GO TO QUESTION 26)
+   No (SKIP TO QUESTION 27)
+Note:   This item only appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        122                0.75 
+1                   Yes                                                       559                3.45 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D26
+Position:   6672
+Length:     3
+Label:      Number of school days missed during 2002-2003 school year
+
+Description:
+   26. About how many school days did you miss during the 2002-2003
+   school year? (If you left school during that year, count only the
+   days you missed before you left.)
+   School days
+Note:   This item only appears on the dropout questionnaire. Values
+greater than 150 were set to 150.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                            0              150.00               23.16               27.14 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D27A
+Position:   6675
+Length:     2
+Label:      Years of General Science coursework (DO)
+
+Description:
+   27. From the beginning of ninth grade until you left high school,
+   how many years of science coursework did you complete in each of
+   the following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   a. General science
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S16A. Unless otherwise noted below, F1S16A is
+identical to F1D27A. However, the variable F1D27A contains
+only data collected from dropouts. F1S16A is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      304                1.88 
+2                   Half year                                                  90                0.56 
+3                   1 year                                                    184                1.14 
+4                   More than 1 year                                           75                0.46 
+-9                  Missing                                                    11                0.07 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                 15                0.09 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D27B
+Position:   6677
+Length:     2
+Label:      Years of General Physical Science coursework (DO)
+
+Description:
+   27. From the beginning of ninth grade until you left high school,
+   how many years of science coursework did you complete in each of
+   the following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   b. General physical science
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S16B. Unless otherwise noted below, F1S16B is
+identical to F1D27B. However, the variable F1D27B contains
+only data collected from dropouts. F1S16B is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      317                1.96 
+2                   Half year                                                 100                0.62 
+3                   1 year                                                    198                1.22 
+4                   More than 1 year                                           44                0.27 
+-9                  Missing                                                    10                0.06 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                 11                0.07 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D27C
+Position:   6679
+Length:     2
+Label:      Years of Biology coursework (DO)
+
+Description:
+   27. From the beginning of ninth grade until you left high school,
+   how many years of science coursework did you complete in each of
+   the following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   c. Biology
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S16C. Unless otherwise noted below, F1S16C is
+identical to F1D27C. However, the variable F1D27C contains
+only data collected from dropouts. F1S16C is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                       99                0.61 
+2                   Half year                                                 147                0.91 
+3                   1 year                                                    305                1.88 
+4                   More than 1 year                                          114                0.70 
+-9                  Missing                                                     5                0.03 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-6                  Multiple response                                           2                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  8                0.05 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D27D
+Position:   6681
+Length:     2
+Label:      Years of Botany/Zoology coursework (DO)
+
+Description:
+   27. From the beginning of ninth grade until you left high school,
+   how many years of science coursework did you complete in each of
+   the following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   d. Botany or zoology
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S16D. Unless otherwise noted below, F1S16D is
+identical to F1D27D. However, the variable F1D27D contains
+only data collected from dropouts. F1S16D is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      585                3.61 
+2                   Half year                                                  37                0.23 
+3                   1 year                                                     25                0.15 
+4                   More than 1 year                                           10                0.06 
+-9                  Missing                                                    13                0.08 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  9                0.06 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D27E
+Position:   6683
+Length:     2
+Label:      Years of Earth Science coursework (DO)
+
+Description:
+   27. From the beginning of ninth grade until you left high school,
+   how many years of science coursework did you complete in each of
+   the following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   e. Earth science
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S16E. Unless otherwise noted below, F1S16E is
+identical to F1D27E. However, the variable F1D27E contains
+only data collected from dropouts. F1S16E is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      254                1.57 
+2                   Half year                                                 123                0.76 
+3                   1 year                                                    230                1.42 
+4                   More than 1 year                                           52                0.32 
+-9                  Missing                                                    11                0.07 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                 10                0.06 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D27F
+Position:   6685
+Length:     2
+Label:      Years of Chemistry coursework (DO)
+
+Description:
+   27. From the beginning of ninth grade until you left high school,
+   how many years of science coursework did you complete in each of
+   the following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   f. Chemistry
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S16F. Unless otherwise noted below, F1S16F is
+identical to F1D27F. However, the variable F1D27F contains
+only data collected from dropouts. F1S16F is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      414                2.56 
+2                   Half year                                                 104                0.64 
+3                   1 year                                                    131                0.81 
+4                   More than 1 year                                           14                0.09 
+-9                  Missing                                                     8                0.05 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  8                0.05 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D27G
+Position:   6687
+Length:     2
+Label:      Years of Principles of Technology coursework (DO)
+
+Description:
+   27. From the beginning of ninth grade until you left high school,
+   how many years of science coursework did you complete in each of
+   the following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   g. Principles of technology
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S16G. Unless otherwise noted below, F1S16G is
+identical to F1D27G. However, the variable F1D27G contains
+only data collected from dropouts. F1S16G is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      581                3.59 
+2                   Half year                                                  36                0.22 
+3                   1 year                                                     32                0.20 
+4                   More than 1 year                                            9                0.06 
+-9                  Missing                                                    12                0.07 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                 10                0.06 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D27H
+Position:   6689
+Length:     2
+Label:      Years of Physics coursework (DO)
+
+Description:
+   27. From the beginning of ninth grade until you left high school,
+   how many years of science coursework did you complete in each of
+   the following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   h. Physics
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S16H. Unless otherwise noted below, F1S16H is
+identical to F1D27H. However, the variable F1D27H contains
+only data collected from dropouts. F1S16H is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      500                3.09 
+2                   Half year                                                  71                0.44 
+3                   1 year                                                     69                0.43 
+4                   More than 1 year                                           20                0.12 
+-9                  Missing                                                    11                0.07 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  9                0.06 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D27I
+Position:   6691
+Length:     2
+Label:      Years of other science coursework (DO)
+
+Description:
+   27. From the beginning of ninth grade until you left high school,
+   how many years of science coursework did you complete in each of
+   the following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   i. Other science
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S16I. Unless otherwise noted below, F1S16I is
+identical to F1D27I. However, the variable F1D27I contains
+only data collected from dropouts. F1S16I is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      522                3.22 
+2                   Half year                                                  53                0.33 
+3                   1 year                                                     62                0.38 
+4                   More than 1 year                                           17                0.11 
+-9                  Missing                                                    15                0.09 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                 10                0.06 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D28A
+Position:   6693
+Length:     2
+Label:      Years of General Math coursework (DO)
+
+Description:
+   28. From the beginning of ninth grade until you left high school,
+   how many years of math coursework did you complete in each of the
+   following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   a. General math
+Note:   This is one of a series of items, a through j. This is the
+dropout version of F1S17A. Unless otherwise noted below, F1S17A is
+identical to F1D28A. However, the variable F1D28A contains
+only data collected from dropouts. F1S17A is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      347                2.14 
+2                   Half year                                                  68                0.42 
+3                   1 year                                                    181                1.12 
+4                   More than 1 year                                           67                0.41 
+-9                  Missing                                                    10                0.06 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  7                0.04 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D28B
+Position:   6695
+Length:     2
+Label:      Years of Pre-Algebra coursework (DO)
+
+Description:
+   28. From the beginning of ninth grade until you left high school,
+   how many years of math coursework did you complete in each of the
+   following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   b. Pre-Algebra
+Note:   This is one of a series of items, a through j. This is the
+dropout version of F1S17B. Unless otherwise noted below, F1S17B is
+identical to F1D28B. However, the variable F1D28B contains
+only data collected from dropouts. F1S17B is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      174                1.07 
+2                   Half year                                                 128                0.79 
+3                   1 year                                                    307                1.90 
+4                   More than 1 year                                           59                0.36 
+-9                  Missing                                                     7                0.04 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  4                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D28C
+Position:   6697
+Length:     2
+Label:      Years of Algebra I coursework (DO)
+
+Description:
+   28. From the beginning of ninth grade until you left high school,
+   how many years of math coursework did you complete in each of the
+   following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   c. Algebra I
+Note:   This is one of a series of items, a through j. This is the
+dropout version of F1S17C. Unless otherwise noted below, F1S17C is
+identical to F1D28C. However, the variable F1D28C contains
+only data collected from dropouts. F1S17C is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      136                0.84 
+2                   Half year                                                 150                0.93 
+3                   1 year                                                    340                2.10 
+4                   More than 1 year                                           41                0.25 
+-9                  Missing                                                     7                0.04 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  6                0.04 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D28D
+Position:   6699
+Length:     2
+Label:      Years of Geometry coursework (DO)
+
+Description:
+   28. From the beginning of ninth grade until you left high school,
+   how many years of math coursework did you complete in each of the
+   following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   d. Geometry
+Note:   This is one of a series of items, a through j. This is the
+dropout version of F1S17D. Unless otherwise noted below, F1S17D is
+identical to F1D28D. However, the variable F1D28D contains
+only data collected from dropouts. F1S17D is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      313                1.93 
+2                   Half year                                                 138                0.85 
+3                   1 year                                                    199                1.23 
+4                   More than 1 year                                           15                0.09 
+-9                  Missing                                                     7                0.04 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  8                0.05 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D28E
+Position:   6701
+Length:     2
+Label:      Years of Algebra II coursework (DO)
+
+Description:
+   28. From the beginning of ninth grade until you left high school,
+   how many years of math coursework did you complete in each of the
+   following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   e. Algebra II
+Note:   This is one of a series of items, a through j. This is the
+dropout version of F1S17E. Unless otherwise noted below, F1S17E is
+identical to F1D28E. However, the variable F1D28E contains
+only data collected from dropouts. F1S17E is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      433                2.67 
+2                   Half year                                                 110                0.68 
+3                   1 year                                                    114                0.70 
+4                   More than 1 year                                            5                0.03 
+-9                  Missing                                                    10                0.06 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  7                0.04 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D28F
+Position:   6703
+Length:     2
+Label:      Years of Trigonometry coursework (DO)
+
+Description:
+   28. From the beginning of ninth grade until you left high school,
+   how many years of math coursework did you complete in each of the
+   following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   f. Trigonometry
+Note:   This is one of a series of items, a through j. This is the
+dropout version of F1S17F. Unless otherwise noted below, F1S17F is
+identical to F1D28F. However, the variable F1D28F contains
+only data collected from dropouts. F1S17F is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      612                3.78 
+2                   Half year                                                  29                0.18 
+3                   1 year                                                     23                0.14 
+4                   More than 1 year                                            1                0.01 
+-9                  Missing                                                    10                0.06 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  4                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D28G
+Position:   6705
+Length:     2
+Label:      Years of Pre-Calculus coursework (DO)
+
+Description:
+   28. From the beginning of ninth grade until you left high school,
+   how many years of math coursework did you complete in each of the
+   following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   g. Pre-Calculus
+Note:   This is one of a series of items, a through j. This is the
+dropout version of F1S17G. Unless otherwise noted below, F1S17G is
+identical to F1D28G. However, the variable F1D28G contains
+only data collected from dropouts. F1S17G is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      624                3.85 
+2                   Half year                                                  25                0.15 
+3                   1 year                                                     17                0.11 
+4                   More than 1 year                                            1                0.01 
+-9                  Missing                                                    10                0.06 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D28H
+Position:   6707
+Length:     2
+Label:      Years of Calculus coursework (DO)
+
+Description:
+   28. From the beginning of ninth grade until you left high school,
+   how many years of math coursework did you complete in each of the
+   following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   h. Calculus
+Note:   This is one of a series of items, a through j. This is the
+dropout version of F1S17H. Unless otherwise noted below, F1S17H is
+identical to F1D28H. However, the variable F1D28H contains
+only data collected from dropouts. F1S17H is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      641                3.96 
+2                   Half year                                                  13                0.08 
+3                   1 year                                                      8                0.05 
+4                   More than 1 year                                            1                0.01 
+-9                  Missing                                                    14                0.09 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D28I
+Position:   6709
+Length:     2
+Label:      Years of Consumer/Business Math coursework (DO)
+
+Description:
+   28. From the beginning of ninth grade until you left high school,
+   how many years of math coursework did you complete in each of the
+   following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   i. Consumer or Business math
+Note:   This is one of a series of items, a through j. This is the
+dropout version of F1S17I. Unless otherwise noted below, F1S17I is
+identical to F1D28I. However, the variable F1D28I contains
+only data collected from dropouts. F1S17I is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      555                3.43 
+2                   Half year                                                  58                0.36 
+3                   1 year                                                     47                0.29 
+4                   More than 1 year                                            4                0.02 
+-9                  Missing                                                    12                0.07 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  4                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D28J
+Position:   6711
+Length:     2
+Label:      Years of other math coursework (DO)
+
+Description:
+   28. From the beginning of ninth grade until you left high school,
+   how many years of math coursework did you complete in each of the
+   following subjects? Count only courses that met at least three
+   times (or three periods) a week for at least one half year. Also
+   include summer school and AP (advanced placement) classes.
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None or less than half a year; Half year; 1 year; More than 1
+   year)
+   j. Other math
+Note:   This is one of a series of items, a through j. This is the
+dropout version of F1S17J. Unless otherwise noted below, F1S17J is
+identical to F1D28J. However, the variable F1D28J contains
+only data collected from dropouts. F1S17J is in present
+tense. Question stem wording change: 'until you left high school' is
+replaced with 'to the end of this school year'; 'did you complete' is
+replaced with "will you have completed'; 'met' is replaced with
+'meet'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      580                3.58 
+2                   Half year                                                  34                0.21 
+3                   1 year                                                     32                0.20 
+4                   More than 1 year                                           17                0.11 
+-9                  Missing                                                    11                0.07 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     2                0.01 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  5                0.03 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29A
+Position:   6713
+Length:     2
+Label:      Left school because got a job (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   a. You got a job
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22A) questionnaire, which is
+identical. However, the variable F1D29A contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        501                3.09 
+1                   Yes                                                       174                1.07 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-2                  Refused                                                     2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29B
+Position:   6715
+Length:     2
+Label:      Left school because did not like school (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   b. You didn't like school
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22B) questionnaire, which is
+identical. However, the variable F1D29B contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        432                2.67 
+1                   Yes                                                       244                1.51 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-2                  Refused                                                     1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29C
+Position:   6717
+Length:     2
+Label:      Left school because could not get along with teachers (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   c. You couldn't get along with your teachers
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22C) questionnaire, which is
+identical. However, the variable F1D29C contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        520                3.21 
+1                   Yes                                                       157                0.97 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29D
+Position:   6719
+Length:     2
+Label:      Left school because could not get along with other students (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   d. You couldn't get along with other students
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22D) questionnaire, which is
+identical. However, the variable F1D29D contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        557                3.44 
+1                   Yes                                                       116                0.72 
+-9                  Missing                                                     6                0.04 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29E
+Position:   6721
+Length:     2
+Label:      Left school because was pregnant (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   e. (FOR FEMALES ONLY) You were pregnant
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22E) questionnaire, which is
+identical. However, the variable F1D29E contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        210                1.30 
+1                   Yes                                                        86                0.53 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   380                2.35 
+-2                  Refused                                                     1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29F
+Position:   6723
+Length:     2
+Label:      Left school because became father/mother of a baby (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   f. You became the father/mother of a baby
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22F) questionnaire, which is
+identical. However, the variable F1D29F contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        572                3.53 
+1                   Yes                                                       104                0.64 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29G
+Position:   6725
+Length:     2
+Label:      Left school because had to support family (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   g. You had to support your family
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22G) questionnaire, which is
+identical. However, the variable F1D29G contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        540                3.33 
+1                   Yes                                                       136                0.84 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29H
+Position:   6727
+Length:     2
+Label:      Left school because was suspended (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   h. You were suspended from school
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22H) questionnaire, which is
+identical. However, the variable F1D29H contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        564                3.48 
+1                   Yes                                                       112                0.69 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29I
+Position:   6729
+Length:     2
+Label:      Left school because did not feel safe (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   i. You did not feel safe at school
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22I) questionnaire, which is
+identical. However, the variable F1D29I contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        613                3.78 
+1                   Yes                                                        61                0.38 
+-9                  Missing                                                     5                0.03 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29J
+Position:   6731
+Length:     2
+Label:      Left school to care for a member of family (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   j. You had to care for a member of your family
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22J) questionnaire, which is
+identical. However, the variable F1D29J contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        568                3.51 
+1                   Yes                                                       107                0.66 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29K
+Position:   6733
+Length:     2
+Label:      Left school because was expelled (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   k. You were expelled from school
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22K) questionnaire, which is
+identical. However, the variable F1D29K contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        607                3.75 
+1                   Yes                                                        68                0.42 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29L
+Position:   6735
+Length:     2
+Label:      Left school because did not feel belonged there (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   l. You felt you didn't belong at school
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22L) questionnaire, which is
+identical. However, the variable F1D29L contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        546                3.37 
+1                   Yes                                                       129                0.80 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29M
+Position:   6737
+Length:     2
+Label:      Left school because could not keep up with schoolwork (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   m. You couldn't keep up with your schoolwork
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22M) questionnaire, which is
+identical. However, the variable F1D29M contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        454                2.80 
+1                   Yes                                                       219                1.35 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29N
+Position:   6739
+Length:     2
+Label:      Left school because was getting poor grades/failing school (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   n. You were getting poor grades/failing school
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22N) questionnaire, which is
+identical. However, the variable F1D29N contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        408                2.52 
+1                   Yes                                                       268                1.65 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29O
+Position:   6741
+Length:     2
+Label:      Left school because got married/planned to get married (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   o. You got married or planned to get married
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22O) questionnaire, which is
+identical. However, the variable F1D29O contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        626                3.86 
+1                   Yes                                                        49                0.30 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29P
+Position:   6743
+Length:     2
+Label:      Left school because changed schools and did not like new one (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   p. You changed schools and didn't like your new school
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22P) questionnaire, which is
+identical. However, the variable F1D29P contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        600                3.70 
+1                   Yes                                                        76                0.47 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29Q
+Position:   6745
+Length:     2
+Label:      Left school because could not work at same time (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   q. You couldn't work and go to school at the same time
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22Q) questionnaire, which is
+identical. However, the variable F1D29Q contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        534                3.30 
+1                   Yes                                                       141                0.87 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29R
+Position:   6747
+Length:     2
+Label:      Left school because thought would fail competency test (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   r. You thought you would not pass the state competency test
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22R) questionnaire, which is
+identical. However, the variable F1D29R contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        595                3.67 
+1                   Yes                                                        76                0.47 
+-9                  Missing                                                     7                0.04 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29S
+Position:   6749
+Length:     2
+Label:      Left school because thought couldn't complete course requirements (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   s. You thought you would not be able to complete the high school
+   coursework requirements
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22S) questionnaire, which is
+identical. However, the variable F1D29S contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        493                3.04 
+1                   Yes                                                       181                1.12 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29T
+Position:   6751
+Length:     2
+Label:      Left school because thought it would be easier to get GED (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   t. You thought it would be easier to get a GED
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22T) questionnaire, which is
+identical. However, the variable F1D29T contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        402                2.48 
+1                   Yes                                                       272                1.68 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D29U
+Position:   6753
+Length:     2
+Label:      Left school because missed too many school days (DO)
+
+Description:
+   29. Here are some reasons other people have given for leaving
+   school. Which of these would you say applied to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   u. You missed too many school days
+Note:   This is one of a series of items, a through u. This item also
+appears on the early graduate (F1E22U) questionnaire, which is
+identical. However, the variable F1D29U contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        388                2.40 
+1                   Yes                                                       287                1.77 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D30
+Position:   6755
+Length:     2
+Label:      Feels that leaving school was a good decision (DO)
+
+Description:
+   30. On the whole, do you feel that leaving school was a good
+   decision for you?
+   Yes
+   No
+   Don't know
+Note:   This item also appears on the early graduate (F1E23)
+questionnaire, which is identical. However, the variable F1D30
+contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Yes                                                       139                0.86 
+2                   No                                                        443                2.74 
+3                   Don't know                                                 91                0.56 
+-9                  Missing                                                     5                0.03 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-2                  Refused                                                     1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D31A
+Position:   6757
+Length:     2
+Label:      Someone from school offered to send you to another school
+
+Description:
+   31. Did anyone from your school do any of the following the last
+   time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   a. Offered to send you to another school
+Note:   This is one of a series of items, a through l. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        542                3.35 
+1                   Yes                                                       131                0.81 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  4                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D31B
+Position:   6759
+Length:     2
+Label:      Someone from school offered to put you in special program
+
+Description:
+   31. Did anyone from your school do any of the following the last
+   time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   b. Offered to put you in a special program
+Note:   This is one of a series of items, a through l. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        527                3.25 
+1                   Yes                                                       147                0.91 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D31C
+Position:   6761
+Length:     2
+Label:      Someone from school offered special tutoring
+
+Description:
+   31. Did anyone from your school do any of the following the last
+   time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   c. Offered special tutoring
+Note:   This is one of a series of items, a through l. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        556                3.43 
+1                   Yes                                                       112                0.69 
+-9                  Missing                                                     9                0.06 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D31D
+Position:   6763
+Length:     2
+Label:      Someone from school offered to help make up missed work
+
+Description:
+   31. Did anyone from your school do any of the following the last
+   time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   d. Offered to help you make up work you missed
+Note:   This is one of a series of items, a through l. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        463                2.86 
+1                   Yes                                                       211                1.30 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D31E
+Position:   6765
+Length:     2
+Label:      Someone from school offered to help with personal problems
+
+Description:
+   31. Did anyone from your school do any of the following the last
+   time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   e. Offered to help you with personal problems
+Note:   This is one of a series of items, a through l. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        520                3.21 
+1                   Yes                                                       154                0.95 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D31F
+Position:   6767
+Length:     2
+Label:      Someone from school told you that you could return if kept grades up
+
+Description:
+   31. Did anyone from your school do any of the following the last
+   time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   f. Told you you could come back if you kept a certain grade point
+   average
+Note:   This is one of a series of items, a through l. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        569                3.51 
+1                   Yes                                                       107                0.66 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D31G
+Position:   6769
+Length:     2
+Label:      Someone from school told you you could return if attendance improved
+
+Description:
+   31. Did anyone from your school do any of the following the last
+   time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   g. Told you you could come back if you didn't miss school so
+   often
+Note:   This is one of a series of items, a through l. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        545                3.36 
+1                   Yes                                                       128                0.79 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D31H
+Position:   6771
+Length:     2
+Label:      Someone from school told you you could return if followed school rules
+
+Description:
+   31. Did anyone from your school do any of the following the last
+   time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   h. Told you you could come back if you followed school discipline
+   rules
+Note:   This is one of a series of items, a through l. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        582                3.59 
+1                   Yes                                                        93                0.57 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D31I
+Position:   6773
+Length:     2
+Label:      Someone from school tried to talk you into staying
+
+Description:
+   31. Did anyone from your school do any of the following the last
+   time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   i. Tried to talk you into staying
+Note:   This is one of a series of items, a through l. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        435                2.69 
+1                   Yes                                                       240                1.48 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     3                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D31J
+Position:   6775
+Length:     2
+Label:      Someone from school told you that you couldn't come back
+
+Description:
+   31. Did anyone from your school do any of the following the last
+   time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   j. Told you you couldn't come back
+Note:   This is one of a series of items, a through l. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        560                3.46 
+1                   Yes                                                       110                0.68 
+-9                  Missing                                                     6                0.04 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-2                  Refused                                                     1                0.01 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D31K
+Position:   6777
+Length:     2
+Label:      Someone from school expelled or suspended you
+
+Description:
+   31. Did anyone from your school do any of the following the last
+   time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   k. Expelled or suspended you
+Note:   This is one of a series of items, a through l. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        574                3.54 
+1                   Yes                                                        99                0.61 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D31L
+Position:   6779
+Length:     2
+Label:      Someone from school called or visited your home
+
+Description:
+   31. Did anyone from your school do any of the following the last
+   time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   l. Called or visited your home
+Note:   This is one of a series of items, a through l. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        513                3.17 
+1                   Yes                                                       158                0.98 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-6                  Multiple response                                           2                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32A
+Position:   6781
+Length:     2
+Label:      Parents/guardians offered to send you to another school
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   a. Offered to send you to another school
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        391                2.41 
+1                   Yes                                                       283                1.75 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32B
+Position:   6783
+Length:     2
+Label:      Parents/guardians offered to put you in special program
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   b. Offered to put you in a special program
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        498                3.07 
+1                   Yes                                                       175                1.08 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32C
+Position:   6785
+Length:     2
+Label:      Parents/guardians offered special tutoring
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   c. Offered to arrange for special tutoring
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        519                3.20 
+1                   Yes                                                       147                0.91 
+-9                  Missing                                                     9                0.06 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32D
+Position:   6787
+Length:     2
+Label:      Parents/guardians offered to help make up missed work
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   d. Offered to help you make up work you missed
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        451                2.78 
+1                   Yes                                                       221                1.36 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32E
+Position:   6789
+Length:     2
+Label:      Parents/guardians offered to help with personal problems
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   e. Offered to help you with personal problems
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        327                2.02 
+1                   Yes                                                       345                2.13 
+-9                  Missing                                                     5                0.03 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32F
+Position:   6791
+Length:     2
+Label:      Parents/guardians tried to talk you into staying
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   f. Tried to talk you into staying in school
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        174                1.07 
+1                   Yes                                                       499                3.08 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32G
+Position:   6793
+Length:     2
+Label:      Parents/guardians told you it was okay to leave
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   g. Told you it was "OK" to leave
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        551                3.40 
+1                   Yes                                                       121                0.75 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32H
+Position:   6795
+Length:     2
+Label:      Parents/guardians told you they were upset
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   h. Told you they were upset
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        236                1.46 
+1                   Yes                                                       437                2.70 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32I
+Position:   6797
+Length:     2
+Label:      Parents/guardians punished you for leaving school
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   i. Punished you for leaving school
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        581                3.59 
+1                   Yes                                                        92                0.57 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32J
+Position:   6799
+Length:     2
+Label:      Parents/guardians told you it was your decision
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   j. Told you it was your decision to make
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        171                1.06 
+1                   Yes                                                       500                3.09 
+-9                  Missing                                                     5                0.03 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32K
+Position:   6801
+Length:     2
+Label:      Parents/guardians called principle or teacher
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   k. Called your principal/teacher
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        469                2.90 
+1                   Yes                                                       202                1.25 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32L
+Position:   6803
+Length:     2
+Label:      Parents/guardians called school counselor
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   l. Called a school counselor
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        463                2.86 
+1                   Yes                                                       205                1.27 
+-9                  Missing                                                     6                0.04 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  4                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D32M
+Position:   6805
+Length:     2
+Label:      Parents/guardians offered to arrange for outside counseling
+
+Description:
+   32. Did your parents or guardians do any of the following the
+   last time you stopped going to school?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   m. Offered to arrange for outside counseling for you (with a
+   psychologist or social worker)
+Note:   This is one of a series of items, a through m. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        585                3.61 
+1                   Yes                                                        88                0.54 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D33A
+Position:   6807
+Length:     2
+Label:      Looked into alternative school in past 2 years
+
+Description:
+   33. In the past 2 years, did any of the following things happen
+   to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   a. You looked into an alternative school
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        427                2.64 
+1                   Yes                                                       248                1.53 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D33B
+Position:   6809
+Length:     2
+Label:      Saw counselor/social worker in past 2 years
+
+Description:
+   33. In the past 2 years, did any of the following things happen
+   to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   b. You saw a counselor or social worker
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        524                3.24 
+1                   Yes                                                       151                0.93 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D33C
+Position:   6811
+Length:     2
+Label:      Went to youth center/outreach program in past 2 years
+
+Description:
+   33. In the past 2 years, did any of the following things happen
+   to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   c. You went to a youth center or outreach program
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        620                3.83 
+1                   Yes                                                        55                0.34 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D33D
+Position:   6813
+Length:     2
+Label:      Went to family counseling in past 2 years
+
+Description:
+   33. In the past 2 years, did any of the following things happen
+   to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   d. You went to family counseling
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        628                3.88 
+1                   Yes                                                        47                0.29 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D33E
+Position:   6815
+Length:     2
+Label:      Did work for religious group in past 2 years
+
+Description:
+   33. In the past 2 years, did any of the following things happen
+   to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   e. You did work for your religious group
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        619                3.82 
+1                   Yes                                                        56                0.35 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D33F
+Position:   6817
+Length:     2
+Label:      In drug rehabilitation program in past 2 years
+
+Description:
+   33. In the past 2 years, did any of the following things happen
+   to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   f. You were in a drug rehabilitation program
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        646                3.99 
+1                   Yes                                                        30                0.19 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D33G
+Position:   6819
+Length:     2
+Label:      In alcohol rehabilitation program in past 2 years
+
+Description:
+   33. In the past 2 years, did any of the following things happen
+   to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   g. You were in an alcohol rehabilitation program
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        659                4.07 
+1                   Yes                                                        18                0.11 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D33H
+Position:   6821
+Length:     2
+Label:      Failed competency test required for graduation in past 2 years
+
+Description:
+   33. In the past 2 years, did any of the following things happen
+   to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   h. You failed a competency test required for high school
+   graduation
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        624                3.85 
+1                   Yes                                                        47                0.29 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  5                0.03 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D33I
+Position:   6823
+Length:     2
+Label:      Held back a grade in past 2 years
+
+Description:
+   33. In the past 2 years, did any of the following things happen
+   to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   i. You were held back a grade in school
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        448                2.77 
+1                   Yes                                                       224                1.38 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-6                  Multiple response                                           2                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D33J
+Position:   6825
+Length:     2
+Label:      Failed a course in past 2 years
+
+Description:
+   33. In the past 2 years, did any of the following things happen
+   to you?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   j. You failed a course in school
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        279                1.72 
+1                   Yes                                                       396                2.44 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D34
+Position:   6827
+Length:     2
+Label:      Participated in an alternative program
+
+Description:
+   34. Have you ever participated in an alternative program?
+   Yes (GO TO QUESTION 35 ON PAGE 12)
+   No (SKIP TO QUESTION 41 ON PAGE 13)
+Note:   This item only appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        490                3.03 
+1                   Yes                                                       184                1.14 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D35
+Position:   6829
+Length:     6
+Label:      Month and year entered most recent alternative program
+
+Description:
+   35. When did you enter the most recent alternative program in
+   which you have participated?
+   Month
+   January
+   February
+   March
+   April
+   May
+   June
+   July
+   August
+   September
+   October
+   November
+   December
+   Year
+   1999 or before
+   2000
+   2001
+   2002
+   2003
+   2004
+Note:   This item only appears on the dropout questionnaire. Data
+provided in a single (yyyymm) format.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                    199900.00           200405.00           200270.18              126.82 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D36
+Position:   6835
+Length:     2
+Label:      Still enrolled in alternative program
+
+Description:
+   36. Are you still enrolled in this program?
+   (MARK ONE RESPONSE)
+   Yes (SKIP TO QUESTION 38 ON PAGE 13)
+   No, you left before completing the program (GO TO QUESTION 37)
+   No, you completed the program (GO TO QUESTION 37)
+Note:   This item only appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Yes                                                        48                0.30 
+2                   No, left before completing the program                     95                0.59 
+3                   No, completed the program                                  39                0.24 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  4                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D37
+Position:   6837
+Length:     6
+Label:      Month and year left/completed most recent alternative program
+
+Description:
+   37. When did you leave or complete the most recent alternative
+   program?
+   Month
+   January
+   February
+   March
+   April
+   May
+   June
+   July
+   August
+   September
+   October
+   November
+   December
+   Year
+   1999 or before
+   2000
+   2001
+   2002
+   2003
+   2004
+Note:   This item only appears on the dropout questionnaire. Data
+provided in a single (yyyymm) format.
+Applies to: Respondents who are no longer in an alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                    199900.00           200406.00           200284.63              116.72 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D38A
+Position:   6843
+Length:     2
+Label:      Parents referred you to this alternative program
+
+Description:
+   38. Which of the following people referred you to this
+   alternative program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   a. Your parent(s)
+Note:   This is one of a series of items, a through k. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        119                0.73 
+1                   Yes                                                        65                0.40 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D38B
+Position:   6845
+Length:     2
+Label:      Siblings referred you to this alternative program
+
+Description:
+   38. Which of the following people referred you to this
+   alternative program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   b. Your brother(s)/sister(s)
+Note:   This is one of a series of items, a through k. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        165                1.02 
+1                   Yes                                                        19                0.12 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D38C
+Position:   6847
+Length:     2
+Label:      Teacher referred you to this alternative program
+
+Description:
+   38. Which of the following people referred you to this
+   alternative program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   c. A teacher
+Note:   This is one of a series of items, a through k. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        127                0.78 
+1                   Yes                                                        56                0.35 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D38D
+Position:   6849
+Length:     2
+Label:      School principal referred you to this alternative program
+
+Description:
+   38. Which of the following people referred you to this
+   alternative program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   d. A school principal
+Note:   This is one of a series of items, a through k. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        131                0.81 
+1                   Yes                                                        53                0.33 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D38E
+Position:   6851
+Length:     2
+Label:      School counselor referred you to this alternative program
+
+Description:
+   38. Which of the following people referred you to this
+   alternative program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   e. A school counselor
+Note:   This is one of a series of items, a through k. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        115                0.71 
+1                   Yes                                                        69                0.43 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D38F
+Position:   6853
+Length:     2
+Label:      Friend referred you to this alternative program
+
+Description:
+   38. Which of the following people referred you to this
+   alternative program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   f. A friend
+Note:   This is one of a series of items, a through k. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        123                0.76 
+1                   Yes                                                        61                0.38 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D38G
+Position:   6855
+Length:     2
+Label:      Relative referred you to this alternative program
+
+Description:
+   38. Which of the following people referred you to this
+   alternative program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   g. A relative
+Note:   This is one of a series of items, a through k. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        149                0.92 
+1                   Yes                                                        34                0.21 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D38I
+Position:   6857
+Length:     2
+Label:      Social worker/clergy referred you to this alternative program
+
+Description:
+   38. Which of the following people referred you to this
+   alternative program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   h. Your minister, priest, or rabbi
+   i. A social worker
+Note:   This item includes responses to item h. This is one of a
+series of items, a through k. This item only appears on the dropout
+questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        167                1.03 
+1                   Yes                                                        17                0.11 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     4                0.02 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D38J
+Position:   6859
+Length:     2
+Label:      Adult friend/acquaintance referred you to this alternative program
+
+Description:
+   38. Which of the following people referred you to this
+   alternative program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   j. An adult friend or acquaintance outside school
+Note:   This is one of a series of items, a through k. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        144                0.89 
+1                   Yes                                                        39                0.24 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D38K
+Position:   6861
+Length:     2
+Label:      Respondent referred self to this alternative program
+
+Description:
+   38. Which of the following people referred you to this
+   alternative program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   k. Yourself
+Note:   This is one of a series of items, a through k. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                         64                0.40 
+1                   Yes                                                       118                0.73 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D39A
+Position:   6863
+Length:     2
+Label:      Received special instructional programs from this program
+
+Description:
+   39. Have you received or did you receive any of the following
+   services from this program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No; Program does/did not offer)
+   a. Special instructional programs
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Yes                                                        35                0.22 
+2                   No                                                        130                0.80 
+3                   Program did not offer                                      13                0.08 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  5                0.03 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D39B
+Position:   6865
+Length:     2
+Label:      Received vocational/technical/trade skills training from this program
+
+Description:
+   39. Have you received or did you receive any of the following
+   services from this program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No; Program does/did not offer)
+   b. Training in vocational, technical, or trade skills
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Yes                                                        40                0.25 
+2                   No                                                        127                0.78 
+3                   Program did not offer                                      14                0.09 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D39C
+Position:   6867
+Length:     2
+Label:      Received tutoring by teachers from this program
+
+Description:
+   39. Have you received or did you receive any of the following
+   services from this program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No; Program does/did not offer)
+   c. Tutoring by teachers
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Yes                                                        77                0.48 
+2                   No                                                         97                0.60 
+3                   Program did not offer                                       8                0.05 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D39D
+Position:   6869
+Length:     2
+Label:      Received tutoring by other students from this program
+
+Description:
+   39. Have you received or did you receive any of the following
+   services from this program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No; Program does/did not offer)
+   d. Tutoring by other students
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Yes                                                        30                0.19 
+2                   No                                                        141                0.87 
+3                   Program did not offer                                       9                0.06 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D39E
+Position:   6871
+Length:     2
+Label:      Received rewards for attendance/class performance from this program
+
+Description:
+   39. Have you received or did you receive any of the following
+   services from this program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No; Program does/did not offer)
+   e. Incentives or rewards for attendance or classroom performance
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Yes                                                        44                0.27 
+2                   No                                                        122                0.75 
+3                   Program did not offer                                      14                0.09 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D39F
+Position:   6873
+Length:     2
+Label:      Received individual/group counseling from this program
+
+Description:
+   39. Have you received or did you receive any of the following
+   services from this program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No; Program does/did not offer)
+   f. Individual or group counseling
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Yes                                                        32                0.20 
+2                   No                                                        141                0.87 
+3                   Program did not offer                                       8                0.05 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D39G
+Position:   6875
+Length:     2
+Label:      Received career counseling from this program
+
+Description:
+   39. Have you received or did you receive any of the following
+   services from this program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No; Program does/did not offer)
+   g. Career counseling
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Yes                                                        28                0.17 
+2                   No                                                        144                0.89 
+3                   Program did not offer                                       9                0.06 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D39H
+Position:   6877
+Length:     2
+Label:      Received job placement assistance from this program
+
+Description:
+   39. Have you received or did you receive any of the following
+   services from this program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No; Program does/did not offer)
+   h. Job placement assistance
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Yes                                                        36                0.22 
+2                   No                                                        132                0.82 
+3                   Program did not offer                                      12                0.07 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D39I
+Position:   6879
+Length:     2
+Label:      Received health care or referrals from this program
+
+Description:
+   39. Have you received or did you receive any of the following
+   services from this program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No; Program does/did not offer)
+   i. Health care or health care referrals
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Yes                                                        15                0.09 
+2                   No                                                        154                0.95 
+3                   Program did not offer                                      12                0.07 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D39J
+Position:   6881
+Length:     2
+Label:      Received childcare from this program
+
+Description:
+   39. Have you received or did you receive any of the following
+   services from this program?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No; Program does/did not offer)
+   j. Childcare or nurseries for your children
+Note:   This is one of a series of items, a through j. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Yes                                                        14                0.09 
+2                   No                                                        151                0.93 
+3                   Program did not offer                                      15                0.09 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D40
+Position:   6883
+Length:     2
+Label:      Number of alternative programs participated in
+
+Description:
+   40. Altogether, in how many alternative programs have you
+   participated?
+   (MARK ONE RESPONSE)
+   1
+   2
+   3 or 4
+   5 or more
+Note:   This item only appears on the dropout questionnaire.
+Category 4 (participated in 5 or more alternative programs)
+was combined with category 3 (participated in 3 or 4
+alternative programs) for disclosure avoidance purposes.
+Applies to: Respondents who have participated in alternative program.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   1                                                         136                0.84 
+2                   2                                                          34                0.21 
+3                   3 or 4                                                     10                0.06 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   490                3.03 
+-1                  Don't know                                                  5                0.03 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D41
+Position:   6885
+Length:     2
+Label:      Plan to get GED or high school diploma
+
+Description:
+   41. Do you plan to get a GED, high school diploma, or its
+   equivalent?
+   (MARK ONE RESPONSE)
+   You have a GED or other equivalent (GO TO QUESTION 42)
+   Yes (SKIP TO QUESTION 46 ON PAGE 15)
+   No (SKIP TO QUESTION 49 ON PAGE 16)
+Note:   This item only appears on the dropout questionnaire.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   You have GED/equivalent                                    43                0.27 
+2                   Yes                                                       582                3.59 
+3                   No                                                         48                0.30 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D42
+Position:   6887
+Length:     2
+Label:      Program in which GED was earned (DO) - restricted
+
+Description:
+   42. How did you earn the GED or equivalency? What program or
+   school were you enrolled in, if any?
+   (MARK ONE RESPONSE)
+   No program, just took exam
+   Part of job training program
+   Enrolled through adult education
+   Part of a child care program or early childhood program
+   Other (write in below)
+Available only on the restricted-use file.
+Note:   This item also appears on the early graduate (F1E24A)
+questionnaire, which is identical. However, the variable F1D42A
+contains only data collected from dropouts. Values of 5
+(Other) were combined with values of 4 (Part of child care
+program) for disclosure avoidance purposes.
+Applies to: Respondents who have GED/equivalent.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+Variable suppressed with -5 values on the public use file.
+
+                                                                        Frequency 
+Category            Label                                              Unweighted 
+------------------- ----------------------------------------- ------------------- 
+-5                  Suppressed                                             16,197 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D42A
+Position:   6889
+Length:     60
+Label:      Other way in which GED was earned (DO) - restricted
+
+Description:
+   42. How did you earn the GED or equivalency? What program or
+   school were you enrolled in, if any?
+   Specify other
+Available only on the restricted-use file.
+Note:   This item also appears on the early graduate (F1E24A)
+questionnaire, which is identical. However, the variable F1D42A
+contains only data collected from dropouts.
+Applies to: Respondents who have GED/equivalent.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+Variable suppressed with -5 values on the public use file.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D43A
+Position:   6949
+Length:     2
+Label:      Completed GED to improve/advance/keep up to date on current job (DO)
+
+Description:
+   43. Why did you decide to complete your GED or equivalency?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   a. To improve, advance, or keep up to date on current job
+Note:   This is one of a series of items, a through f. This item also
+appears on the early graduate (F1E25A) questionnaire, which is
+identical. However, the variable F1D43A contains only data collected
+from dropouts.
+Applies to: Respondents who have GED/equivalent.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                         20                0.12 
+1                   Yes                                                        23                0.14 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   630                3.89 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D43B
+Position:   6951
+Length:     2
+Label:      Completed GED to train for new job/career (DO)
+
+Description:
+   43. Why did you decide to complete your GED or equivalency?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   b. To train for a new job or new career
+Note:   This is one of a series of items, a through f. This item also
+appears on the early graduate (F1E25B) questionnaire, which is
+identical. However, the variable F1D43B contains only data collected
+from dropouts.
+Applies to: Respondents who have GED/equivalent.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                         21                0.13 
+1                   Yes                                                        22                0.14 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   630                3.89 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D43C
+Position:   6953
+Length:     2
+Label:      Completed GED to improve basic reading writing or math skills (DO)
+
+Description:
+   43. Why did you decide to complete your GED or equivalency?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   c. To improve basic reading, writing or math skills
+Note:   This is one of a series of items, a through f. This item also
+appears on the early graduate (F1E25C) questionnaire, which is
+identical. However, the variable F1D43C contains only data collected
+from dropouts.
+Applies to: Respondents who have GED/equivalent.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                         30                0.19 
+1                   Yes                                                        12                0.07 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   630                3.89 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D43D
+Position:   6955
+Length:     2
+Label:      Completed GED to meet requirements for additional study (DO)
+
+Description:
+   43. Why did you decide to complete your GED or equivalency?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   d. To meet requirements for additional study
+Note:   This is one of a series of items, a through f. This item also
+appears on the early graduate (F1E25D) questionnaire, which is
+identical. However, the variable F1D43D contains only data collected
+from dropouts.
+Applies to: Respondents who have GED/equivalent.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                         19                0.12 
+1                   Yes                                                        24                0.15 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   630                3.89 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D43E
+Position:   6957
+Length:     2
+Label:      Completed GED because required or encouraged by employer (DO)
+
+Description:
+   43. Why did you decide to complete your GED or equivalency?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   e. Required or encouraged by your employer
+Note:   This is one of a series of items, a through f. This item also
+appears on the early graduate (F1E25E) questionnaire, which is
+identical. However, the variable F1D43E contains only data collected
+from dropouts.
+Applies to: Respondents who have GED/equivalent.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                         33                0.20 
+1                   Yes                                                        10                0.06 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   630                3.89 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D43F
+Position:   6959
+Length:     2
+Label:      Completed GED because of personal/family/social reasons (DO)
+
+Description:
+   43. Why did you decide to complete your GED or equivalency?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   f. Personal, family or social reasons
+Note:   This is one of a series of items, a through f. This item also
+appears on the early graduate (F1E25F) questionnaire, which is
+identical. However, the variable F1D43F contains only data collected
+from dropouts.
+Applies to: Respondents who have GED/equivalent.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                         16                0.10 
+1                   Yes                                                        27                0.17 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   630                3.89 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D44
+Position:   6961
+Length:     2
+Label:      State where GED/equivalency was earned (DO) - restricted
+
+Description:
+   44. In what state did you earn your GED or equivalency?
+   (MARK ONE RESPONSE)
+   Alabama
+   Alaska
+   Arizona
+   Arkansas
+   California
+   Colorado
+   Connecticut
+   Delaware
+   District of Columbia
+   Florida
+   Georgia
+   Hawaii
+   Idaho
+   Illinois
+   Indiana
+   Iowa
+   Kansas
+   Kentucky
+   Louisiana
+   Maine
+   Maryland
+   Massachusetts
+   Michigan
+   Minnesota
+   Mississippi
+   Missouri
+   Montana
+   Nebraska
+   Nevada
+   New Hampshire
+   New Jersey
+   New Mexico
+   New York
+   North Carolina
+   North Dakota
+   Ohio
+   Oklahoma
+   Oregon
+   Pennsylvania
+   Rhode Island
+   South Carolina
+   South Dakota
+   Tennessee
+   Texas
+   Utah
+   Vermont
+   Virginia
+   Washington
+   West Virginia
+   Wisconsin
+   Wyoming
+Available only on the restricted-use file.
+Note:   This item also appears on the early graduate (F1E26)
+questionnaire, which is identical. However, the variable F1D44
+contains only data collected from dropouts.
+Applies to: Respondents who have GED/equivalent.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+Variable suppressed with -5 values on the public use file.
+
+                                                                        Frequency 
+Category            Label                                              Unweighted 
+------------------- ----------------------------------------- ------------------- 
+-5                  Suppressed                                             16,197 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D45
+Position:   6963
+Length:     6
+Label:      Month and year when received GED/equivalency (DO)
+
+Description:
+   45. When did you receive your GED, or equivalency?
+   (MARK ONE RESPONSE)
+   March, 2004 (SKIP TO QUESTION 49 ON PAGE 16)
+   April, 2004 (SKIP TO QUESTION 49 ON PAGE 16)
+   May, 2004 (SKIP TO QUESTION 49 ON PAGE 16)
+   June, 2004 (SKIP TO QUESTION 49 ON PAGE 16)
+   July, 2004 (SKIP TO QUESTION 49 ON PAGE 16)
+   August, 2004 (SKIP TO QUESTION 49 ON PAGE 16)
+Note:   This item also appears on the early graduate (F1E27)
+questionnaire. However, the variable F1D45 contains only data
+collected from dropouts. F1E27 is different from the dropout item
+in the following way. Early graduate (F1E27) question stem wording
+change: 'When did you graduate from high school or receive your
+equivalency (for example, GED)?' Response options are different and
+specified by month then year: January, February, March, April, May,
+June, July, August, September, October, November, December, 2002,
+2003, 2004. Dates beyond 200407 were recoded to 200406.
+Applies to: Respondents who have GED/equivalent.
+Source: ELS:2002 First follow-up Dropout Questionnaire
+
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                    200403.00           200406.00           200404.50                1.20 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D46
+Position:   6969
+Length:     11
+Label:      Currently taking class to prepare for GED examination
+
+Description:
+   46. Are you currently taking a class to prepare for the GED
+   examination?
+   Yes (SKIP TO QUESTION 48)
+   No (GO TO QUESTION 47)
+Note:   This item only appears on the dropout questionnaire.
+Applies to: Respondents who plan to get GED/high school diploma/
+equivalent.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D47A
+Position:   6980
+Length:     2
+Label:      Plan to go back to school to get high school diploma
+
+Description:
+   47. Do you plan to do either of the following?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   a. Go back to school to get a high school diploma
+Note:   This is one of a series of items, a through b. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who are not currently taking a class for GED
+exam.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        272                1.68 
+1                   Yes                                                       176                1.09 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   220                1.36 
+-1                  Don't know                                                  6                0.04 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D47B
+Position:   6982
+Length:     2
+Label:      Plan to enroll in class to prepare for GED or equivalent
+
+Description:
+   47. Do you plan to do either of the following?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Yes; No)
+   b. Enroll in a class to prepare for taking the GED or other
+   equivalency test
+Note:   This is one of a series of items, a through b. This item only
+appears on the dropout questionnaire.
+Applies to: Respondents who are not currently taking a class for GED
+exam.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        157                0.97 
+1                   Yes                                                       290                1.79 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   220                1.36 
+-1                  Don't know                                                  6                0.04 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D48
+Position:   6984
+Length:     6
+Label:      Month and year expects to receive high school diploma/GED
+
+Description:
+   48. About when do you expect to receive a high school diploma, or
+   to take the examination for the GED or other high school
+   equivalency exam?
+   Month
+   Year
+   20
+Note:   This item only appears on the dropout questionnaire. Data
+provided in a single (yyyymm) format. All dates beyond 200512
+were recoded as 200600. All dates preceding 200401 were recoded
+as 200400.
+Applies to: Respondents who plan to get GED/high school diploma/
+equivalent.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                    200400.00           200600.00           200431.62               47.49 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D49A
+Position:   6990
+Length:     2
+Label:      Use of public library for leisure reading (DO)
+
+Description:
+   49. How often do you use your public library for any of the
+   following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Never; Rarely; Sometimes; Often)
+   a. Leisure reading
+Note:   This is one of a series of items, a through e (for full
+student, abbreviated student, transfer, and homeschool, a through
+i). This is the dropout version of F1S30A. Unless otherwise noted
+below, F1S30A is identical to F1D49A. However, the variable F1D49A
+contains only data collected from dropouts. F1S30A response
+options are different: 'Course assignments, In-school projects,
+Homework (assignments to be completed outside of class time),
+Research papers' are also included.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Never                                                     367                2.27 
+2                   Rarely                                                    121                0.75 
+3                   Sometimes                                                 136                0.84 
+4                   Often                                                      53                0.33 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D49B
+Position:   6992
+Length:     2
+Label:      Use of public library to read magazines/newspaper (DO)
+
+Description:
+   49. How often do you use your public library for any of the
+   following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Never; Rarely; Sometimes; Often)
+   b. Read magazines or newspapers
+Note:   This is one of a series of items, a through e (for full
+student, abbreviated student, transfer, and homeschool, a through
+i). This is the dropout version of F1S30B. Unless otherwise noted
+below, F1S30B is identical to F1D49B. However, the variable F1D49B
+contains only data collected from dropouts. F1S30B response
+options are different: 'Course assignments, In-school projects,
+Homework (assignments to be completed outside of class time),
+Research papers' are also included.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Never                                                     379                2.34 
+2                   Rarely                                                     87                0.54 
+3                   Sometimes                                                 111                0.69 
+4                   Often                                                     100                0.62 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D49C
+Position:   6994
+Length:     2
+Label:      Use of public library to read books for fun (DO)
+
+Description:
+   49. How often do you use your public library for any of the
+   following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Never; Rarely; Sometimes; Often)
+   c. Read books for fun
+Note:   This is one of a series of items, a through e (for full
+student, abbreviated student, transfer, and homeschool, a through
+i). This is the dropout version of F1S30C. Unless otherwise noted
+below, F1S30C is identical to F1D49C. However, the variable F1D49C
+contains only data collected from dropouts. F1S30C response
+options are different: 'Course assignments, In-school projects,
+Homework (assignments to be completed outside of class time),
+Research papers' are also included.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Never                                                     342                2.11 
+2                   Rarely                                                    109                0.67 
+3                   Sometimes                                                 152                0.94 
+4                   Often                                                      73                0.45 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D49D
+Position:   6996
+Length:     2
+Label:      Use of public library for personal interests (DO)
+
+Description:
+   49. How often do you use your public library for any of the
+   following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Never; Rarely; Sometimes; Often)
+   d. Learn about things such as sports, hobbies, people or music
+Note:   This is one of a series of items, a through e (for full
+student, abbreviated student, transfer, and homeschool, a through
+i). This is the dropout version of F1S30H. Unless otherwise noted
+below, F1S30H is identical to F1D49D. However, the variable F1D49D
+contains only data collected from dropouts. F1S30H response
+options are different: 'Course assignments, In-school projects,
+Homework (assignments to be completed outside of class time),
+Research papers' are also included.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Never                                                     317                1.96 
+2                   Rarely                                                     96                0.59 
+3                   Sometimes                                                 138                0.85 
+4                   Often                                                     125                0.77 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D49E
+Position:   6998
+Length:     2
+Label:      Use of public library for Internet access (DO)
+
+Description:
+   49. How often do you use your public library for any of the
+   following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Never; Rarely; Sometimes; Often)
+   e. Use the Internet
+Note:   This is one of a series of items, a through e (for full
+student, abbreviated student, transfer, and homeschool, a through
+i). This is the dropout version of F1S30E. Unless otherwise noted
+below, F1S30E is identical to F1D49E. However, the variable F1D49E
+contains only data collected from dropouts. F1S30E response
+options are different: 'Course assignments, In-school projects,
+Homework (assignments to be completed outside of class time),
+Research papers' are also included.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Never                                                     300                1.85 
+2                   Rarely                                                     84                0.52 
+3                   Sometimes                                                 148                0.91 
+4                   Often                                                     144                0.89 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D50
+Position:   7000
+Length:     2
+Label:      Hours/week spent reading (DO)
+
+Description:
+   50. How many hours of reading do you do each week?
+   (MARK ONE RESPONSE)
+   None
+   1 hour or less per week
+   2 hours
+   3 hours
+   4-5 hours
+   6-7 hours
+   8-9 hours
+   10 hours or more a week
+Note:   This is the dropout version of F1S33. Unless otherwise noted
+below, F1S33 is identical to F1D50. However, the variable F1D50
+contains only data collected from dropouts. F1S33 question stem
+wording change: 'How many hours of additional reading do you do each
+week on your own outside of school - not in connection with
+schoolwork? (Do not count any school-assigned reading.)'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                       78                0.48 
+2                   1 hour or less per week                                   186                1.15 
+3                   2 hours/week                                              116                0.72 
+4                   3 hours/week                                               87                0.54 
+5                   4-5 hours/week                                             87                0.54 
+6                   6-7 hours/week                                             34                0.21 
+7                   8-9 hours/week                                             27                0.17 
+8                   10 or more hours/week                                      61                0.38 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     5                0.03 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D51A
+Position:   7002
+Length:     2
+Label:      Hours/day spent watching TV/DVD on weekdays (DO)
+
+Description:
+   51. How many hours a day do you usually watch TV, videotapes, or
+   DVDs? BE SURE TO ANSWER BOTH A AND B BELOW.
+   On weekdays
+   (MARK ONE)
+   Don't watch TV, videotapes, or DVDs
+   Less than 1 hour a day
+   1 hour or more, but less than 2
+   2 hours or more, but less than 3
+   3 hours or more, but less than 5
+   5 hours or more a day
+Note:   This is the dropout version of F1S34A. Unless otherwise noted
+below, F1S34A is identical to F1D51A. However, the variable F1D51A
+contains only data collected from dropouts. F1S34A question stem
+wording change: 'During the school year' is included at beginning of
+question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Do not watch television                                    41                0.25 
+2                   Less than 1 hour/day                                       64                0.40 
+3                   1 hour or more but less than 2 hours/day                  100                0.62 
+4                   2 hours or more but less than 3 hours/da                  123                0.76 
+                    y
+5                   3 hours or more but less than 5 hours/da                  168                1.04 
+                    y
+6                   5 hours or more a day                                     166                1.02 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     6                0.04 
+                    or breakoff
+-6                  Multiple response                                           9                0.06 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D51B
+Position:   7004
+Length:     2
+Label:      Hours/day spent watching TV/DVD on weekends (DO)
+
+Description:
+   51. How many hours a day do you usually watch TV, videotapes, or
+   DVDs? BE SURE TO ANSWER BOTH A AND B BELOW.
+   On weekend days
+   (MARK ONE)
+   Don't watch TV, videotapes, or DVDs
+   Less than 1 hour a day
+   1 hour or more, but less than 2
+   2 hours or more, but less than 3
+   3 hours or more, but less than 5
+   5 hours or more a day
+Note:   This is the dropout version of F1S34B. Unless otherwise noted
+below, F1S34B is identical to F1D51B. However, the variable F1D51B
+contains only data collected from dropouts. F1S34B question stem
+wording change: 'During the school year' is included at beginning of
+question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Do not watch television                                    69                0.43 
+2                   Less than 1 hour/day                                       69                0.43 
+3                   1 hour or more but less than 2 hours/day                  105                0.65 
+4                   2 hours or more but less than 3 hours/da                  114                0.70 
+                    y
+5                   3 hours or more but less than 5 hours/da                  146                0.90 
+                    y
+6                   5 hours or more a day                                     154                0.95 
+-9                  Missing                                                     6                0.04 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     6                0.04 
+                    or breakoff
+-6                  Multiple response                                          12                0.07 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D52A
+Position:   7006
+Length:     2
+Label:      Hours/day plays video/computer games on weekdays (DO)
+
+Description:
+   52. How many hours a day do you usually play video or computer
+   games such as Nintendo, Play Station, or XBOX? BE SURE TO ANSWER A
+   AND B BELOW.
+   On weekdays
+   (MARK ONE)
+   Don't play video or computer games
+   Less than 1 hour a day
+   1 hour or more, but less than 2
+   2 hours or more, but less than 3
+   3 hours or more, but less than 5
+   5 hours or more a day
+Note:   This is the dropout version of F1S35A. Unless otherwise noted
+below, F1S35A is identical to F1D52A. However, the variable F1D52A
+contains only data collected from dropouts. F1S35A question stem
+wording change: 'During the school year' is included at beginning of
+question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Do not play video/computer games                          380                2.35 
+2                   Less than 1 hour/day                                       88                0.54 
+3                   1 hour or more but less than 2 hours/day                   83                0.51 
+4                   2 hours or more but less than 3 hours/da                   52                0.32 
+                    y
+5                   3 hours or more but less than 5 hours/da                   38                0.23 
+                    y
+6                   5 hours or more a day                                      23                0.14 
+-9                  Missing                                                     6                0.04 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     6                0.04 
+                    or breakoff
+-6                  Multiple response                                           6                0.04 
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D52B
+Position:   7008
+Length:     2
+Label:      Hours/day plays video/computer games on weekends (DO)
+
+Description:
+   52. How many hours a day do you usually play video or computer
+   games such as Nintendo, Play Station, or XBOX? BE SURE TO ANSWER A
+   AND B BELOW.
+   On weekend days
+   (MARK ONE)
+   Don't play video or computer games
+   Less than 1 hour a day
+   1 hour or more, but less than 2
+   2 hours or more, but less than 3
+   3 hours or more, but less than 5
+   5 hours or more a day
+Note:   This is the dropout version of F1S35B. Unless otherwise noted
+below, F1S35B is identical to F1D52B. However, the variable F1D52B
+contains only data collected from dropouts. F1S35B question stem
+wording change: 'During the school year' is included at beginning of
+question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Do not play video/computer games                          374                2.31 
+2                   Less than 1 hour/day                                       83                0.51 
+3                   1 hour or more but less than 2 hours/day                   76                0.47 
+4                   2 hours or more but less than 3 hours/da                   45                0.28 
+                    y
+5                   3 hours or more but less than 5 hours/da                   45                0.28 
+                    y
+6                   5 hours or more a day                                      36                0.22 
+-9                  Missing                                                     8                0.05 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     6                0.04 
+                    or breakoff
+-6                  Multiple response                                           9                0.06 
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D53
+Position:   7010
+Length:     2
+Label:      Hours/day uses computer (DO)
+
+Description:
+   53. How many hours a day do you usually use a computer?
+   (MARK ONE RESPONSE)
+   None
+   Less than 1 hour a day
+   1 hour or more, but less than 2
+   2 hours or more, but less than 3
+   3 hours or more, but less than 5
+   5 hours or more a day
+Note:   This is the dropout version of F1S36A,B. Unless otherwise
+noted below, F1S36A,B is identical to F1D53. However, the variable
+F1D53 contains only data collected from dropouts. F1S36A,B question
+stem wording change: 'How many hours a day do you usually use a
+computer for schoolwork and other than for schoolwork?' Includes
+both 'For schoolwork' and 'Other than for schoolwork' headings.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      205                1.27 
+2                   Less than 1 hour/day                                      159                0.98 
+3                   1 hour or more but less than 2 hours/day                  115                0.71 
+4                   2 hours or more but less than 3 hours/da                   88                0.54 
+                    y
+5                   3 hours or more but less than 5 hours/da                   61                0.38 
+                    y
+6                   5 hours or more a day                                      46                0.28 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     6                0.04 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D54A
+Position:   7012
+Length:     2
+Label:      How often uses computer at home (DO)
+
+Description:
+   54. How often do you use a computer...
+   (MARK ONE RESPONSE ON EACH LINE)
+   (No computer; Never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   a. at home?
+Note:   This is one of a series of items, a through d (for student
+and transfer, a through f; for early graduate, a through e). This
+is the dropout version of F1S37A. F1S37A is identical to F1D54A.
+However, the variable F1D54A contains only data collected from
+dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   No computer                                               202                1.25 
+2                   Never                                                      74                0.46 
+3                   Less than once a week                                      55                0.34 
+4                   Once or twice a week                                      155                0.96 
+5                   Every day/almost every day                                188                1.16 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     6                0.04 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D54B
+Position:   7014
+Length:     2
+Label:      How often uses computer at public library (DO)
+
+Description:
+   54. How often do you use a computer...
+   (MARK ONE RESPONSE ON EACH LINE)
+   (No computer; Never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   b. at the public library (for activities other than catalog
+   searches)?
+Note:   This is one of a series of items, a through d (for student
+and transfer, a through f; for early graduate, a through e). This
+is the dropout version of F1S37B. F1S37B is identical to F1D54B.
+However, the variable F1D54B contains only data collected from
+dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   No computer                                                47                0.29 
+2                   Never                                                     429                2.65 
+3                   Less than once a week                                      99                0.61 
+4                   Once or twice a week                                       81                0.50 
+5                   Every day/almost every day                                 15                0.09 
+-9                  Missing                                                     5                0.03 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     6                0.04 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D54C
+Position:   7016
+Length:     2
+Label:      How often uses computer at friend's house (DO)
+
+Description:
+   54. How often do you use a computer...
+   (MARK ONE RESPONSE ON EACH LINE)
+   (No computer; Never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   c. at a friend's house?
+Note:   This is one of a series of items, a through d (for student
+and transfer, a through f; for early graduate, a through e). This
+is the dropout version of F1S37C. F1S37C is identical to F1D54C.
+However, the variable F1D54C contains only data collected from
+dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   No computer                                                56                0.35 
+2                   Never                                                     380                2.35 
+3                   Less than once a week                                      96                0.59 
+4                   Once or twice a week                                      110                0.68 
+5                   Every day/almost every day                                 27                0.17 
+-9                  Missing                                                     6                0.04 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     6                0.04 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D54D
+Position:   7018
+Length:     2
+Label:      How often uses computer at another place (DO)
+
+Description:
+   54. How often do you use a computer...
+   (MARK ONE RESPONSE ON EACH LINE)
+   (No computer; Never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   d. at another place?
+Note:   This is one of a series of items, a through d (for student
+and transfer, a through f; for early graduate, a through e). This
+is the dropout version of F1S37D. F1S37D is identical to F1D54D.
+However, the variable F1D54D contains only data collected from
+dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   No computer                                                60                0.37 
+2                   Never                                                     448                2.77 
+3                   Less than once a week                                      66                0.41 
+4                   Once or twice a week                                       67                0.41 
+5                   Every day/almost every day                                 30                0.19 
+-9                  Missing                                                     5                0.03 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     6                0.04 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D55A
+Position:   7020
+Length:     2
+Label:      How often visits with friends at local hangout (DO)
+
+Description:
+   55. How often do you spend time on the following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Rarely or never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   a. Visiting with friends (hanging out)
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S39A. Unless otherwise noted below, F1S39A is
+identical to F1D55A. However, the variable F1D55A contains only data
+collected from dropouts. F1S39A question stem wording change:
+'outside of school' is included at end of question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Rarely or never                                           108                0.67 
+2                   Less than once a week                                      50                0.31 
+3                   Once or twice a week                                      181                1.12 
+4                   Every day/almost every day                                335                2.07 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     7                0.04 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D55B
+Position:   7022
+Length:     2
+Label:      How often works on hobbies (DO)
+
+Description:
+   55. How often do you spend time on the following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Rarely or never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   b. Working on hobbies, arts, crafts
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S39B. Unless otherwise noted below, F1S39B is
+identical to F1D55B. However, the variable F1D55B contains only data
+collected from dropouts. F1S39B question stem wording change:
+'outside of school' is included at end of question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Rarely or never                                           288                1.78 
+2                   Less than once a week                                      70                0.43 
+3                   Once or twice a week                                      135                0.83 
+4                   Every day/almost every day                                179                1.11 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D55C
+Position:   7024
+Length:     2
+Label:      How often performs community services (DO)
+
+Description:
+   55. How often do you spend time on the following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Rarely or never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   c. Volunteering or performing community service
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S39C. Unless otherwise noted below, F1S39C is
+identical to F1D55C. However, the variable F1D55C contains only data
+collected from dropouts. F1S39C question stem wording change:
+'outside of school' is included at end of question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Rarely or never                                           561                3.46 
+2                   Less than once a week                                      37                0.23 
+3                   Once or twice a week                                       45                0.28 
+4                   Every day/almost every day                                 27                0.17 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D55D
+Position:   7026
+Length:     2
+Label:      How often drives or rides around (DO)
+
+Description:
+   55. How often do you spend time on the following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Rarely or never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   d. Driving or riding around with friends or in your own car
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S39D. Unless otherwise noted below, F1S39D is
+identical to F1D55D. However, the variable F1D55D contains only data
+collected from dropouts. F1S39D question stem wording change:
+'outside of school' is included at end of question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Rarely or never                                           242                1.49 
+2                   Less than once a week                                      40                0.25 
+3                   Once or twice a week                                      120                0.74 
+4                   Every day/almost every day                                269                1.66 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D55E
+Position:   7028
+Length:     2
+Label:      How often talks on phone with friends (DO)
+
+Description:
+   55. How often do you spend time on the following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Rarely or never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   e. Talking with friends on the telephone
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S39E. Unless otherwise noted below, F1S39E is
+identical to F1D55E. However, the variable F1D55E contains only data
+collected from dropouts. F1S39E question stem wording change:
+'outside of school' is included at end of question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Rarely or never                                           199                1.23 
+2                   Less than once a week                                      48                0.30 
+3                   Once or twice a week                                      122                0.75 
+4                   Every day/almost every day                                301                1.86 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D55F
+Position:   7030
+Length:     2
+Label:      How often takes music, art, language class (DO)
+
+Description:
+   55. How often do you spend time on the following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Rarely or never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   f. Taking classes: music, art, language, dance
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S39F. Unless otherwise noted below, F1S39F is
+identical to F1D55F. However, the variable F1D55F contains only data
+collected from dropouts. F1S39F question stem wording change:
+'outside of school' is included at end of question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Rarely or never                                           602                3.72 
+2                   Less than once a week                                      10                0.06 
+3                   Once or twice a week                                       29                0.18 
+4                   Every day/almost every day                                 32                0.20 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D55G
+Position:   7032
+Length:     2
+Label:      How often takes sports lessons (DO)
+
+Description:
+   55. How often do you spend time on the following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Rarely or never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   g. Taking sports lessons
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S39G. Unless otherwise noted below, F1S39G is
+identical to F1D55G. However, the variable F1D55G contains only data
+collected from dropouts. F1S39G question stem wording change:
+'outside of school' is included at end of question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Rarely or never                                           604                3.73 
+2                   Less than once a week                                       7                0.04 
+3                   Once or twice a week                                       29                0.18 
+4                   Every day/almost every day                                 32                0.20 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D55H
+Position:   7034
+Length:     2
+Label:      How often plays sports (DO)
+
+Description:
+   55. How often do you spend time on the following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Rarely or never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   h. Playing sports
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S39H. Unless otherwise noted below, F1S39H is
+identical to F1D55H. However, the variable F1D55H contains only data
+collected from dropouts. F1S39H question stem wording change:
+'outside of school' is included at end of question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Rarely or never                                           392                2.42 
+2                   Less than once a week                                      42                0.26 
+3                   Once or twice a week                                      125                0.77 
+4                   Every day/almost every day                                114                0.70 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D55I
+Position:   7036
+Length:     2
+Label:      How often talks with friends/relatives via the Internet (DO)
+
+Description:
+   55. How often do you spend time on the following activities?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Rarely or never; Less than once a week; Once or twice a week;
+   Every day or almost every day)
+   i. Communicating with friends or relatives via the Internet
+Note:   This is one of a series of items, a through i. This is the
+dropout version of F1S39I. Unless otherwise noted below, F1S39I is
+identical to F1D55I. However, the variable F1D55I contains only data
+collected from dropouts. F1S39I question stem wording change:
+'outside of school' is included at end of question.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Rarely or never                                           429                2.65 
+2                   Less than once a week                                      39                0.24 
+3                   Once or twice a week                                      105                0.65 
+4                   Every day/almost every day                                100                0.62 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56A
+Position:   7038
+Length:     2
+Label:      Importance of being successful in line work (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   a. Being successful in your line of work
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40A. F1S40A is identical to F1D56A. However,
+the variable F1D56A contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                              14                0.09 
+2                   Somewhat important                                        101                0.62 
+3                   Very important                                            555                3.43 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-2                  Refused                                                     1                0.01 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56B
+Position:   7040
+Length:     2
+Label:      Importance of marrying right person/having happy family (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   b. Finding the right person to marry and having a happy family
+   life
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40B. F1S40B is identical to F1D56B. However,
+the variable F1D56B contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                              52                0.32 
+2                   Somewhat important                                        104                0.64 
+3                   Very important                                            517                3.19 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56C
+Position:   7042
+Length:     2
+Label:      Importance of having lots of money (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   c. Having lots of money
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40C. F1S40C is identical to F1D56C. However,
+the variable F1D56C contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                             122                0.75 
+2                   Somewhat important                                        253                1.56 
+3                   Very important                                            298                1.84 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56D
+Position:   7044
+Length:     2
+Label:      Importance of having strong friendships (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   d. Having strong friendships
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40D. F1S40D is identical to F1D56D. However,
+the variable F1D56D contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                              40                0.25 
+2                   Somewhat important                                        144                0.89 
+3                   Very important                                            486                3.00 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-2                  Refused                                                     1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56E
+Position:   7046
+Length:     2
+Label:      Importance of being able to find steady work (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   e. Being able to find steady work
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40E. F1S40E is identical to F1D56E. However,
+the variable F1D56E contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                              14                0.09 
+2                   Somewhat important                                         76                0.47 
+3                   Very important                                            582                3.59 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56F
+Position:   7048
+Length:     2
+Label:      Importance of helping others in community (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   f. Helping other people in your community
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40F. F1S40F is identical to F1D56F. However,
+the variable F1D56F contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                              41                0.25 
+2                   Somewhat important                                        323                1.99 
+3                   Very important                                            307                1.90 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56G
+Position:   7050
+Length:     2
+Label:      Importance of giving children better opportunities (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   g. Being able to give your children better opportunities than
+   you've had
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40G. F1S40G is identical to F1D56G. However,
+the variable F1D56G contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                              17                0.11 
+2                   Somewhat important                                         30                0.19 
+3                   Very important                                            621                3.83 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-2                  Refused                                                     1                0.01 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56H
+Position:   7052
+Length:     2
+Label:      Importance of living close to parents/relatives (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   h. Living close to parents and relatives
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40H. F1S40H is identical to F1D56H. However,
+the variable F1D56H contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                             100                0.62 
+2                   Somewhat important                                        306                1.89 
+3                   Very important                                            266                1.64 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56I
+Position:   7054
+Length:     2
+Label:      Importance of getting away from this area (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   i. Getting away from this area of the country
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40I. F1S40I is identical to F1D56I. However,
+the variable F1D56I contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                             323                1.99 
+2                   Somewhat important                                        206                1.27 
+3                   Very important                                            139                0.86 
+-9                  Missing                                                     5                0.03 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56J
+Position:   7056
+Length:     2
+Label:      Importance of working to correct inequalities (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   j. Working to correct social and economic inequalities
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40J. F1S40J is identical to F1D56J. However,
+the variable F1D56J contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                             161                0.99 
+2                   Somewhat important                                        300                1.85 
+3                   Very important                                            205                1.27 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-2                  Refused                                                     1                0.01 
+-1                  Don't know                                                  4                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56K
+Position:   7058
+Length:     2
+Label:      Importance of having children (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   k. Having children
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40K. F1S40K is identical to F1D56K. However,
+the variable F1D56K contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                             141                0.87 
+2                   Somewhat important                                        248                1.53 
+3                   Very important                                            283                1.75 
+-9                  Missing                                                     1                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56L
+Position:   7060
+Length:     2
+Label:      Importance of having leisure time (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   l. Having leisure time to enjoy your own interests
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40L. F1S40L is identical to F1D56L. However,
+the variable F1D56L contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                              37                0.23 
+2                   Somewhat important                                        284                1.75 
+3                   Very important                                            349                2.15 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-2                  Refused                                                     1                0.01 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56M
+Position:   7062
+Length:     2
+Label:      Importance of being expert in field of work (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   m. Becoming an expert in your field of work
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40M. F1S40M is identical to F1D56M. However,
+the variable F1D56M contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                              32                0.20 
+2                   Somewhat important                                        148                0.91 
+3                   Very important                                            487                3.01 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-2                  Refused                                                     2                0.01 
+-1                  Don't know                                                  2                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56N
+Position:   7064
+Length:     2
+Label:      Importance of getting good education (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   n. Getting a good education
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40N. F1S40N is identical to F1D56N. However,
+the variable F1D56N contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                              13                0.08 
+2                   Somewhat important                                        105                0.65 
+3                   Very important                                            553                3.41 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56O
+Position:   7066
+Length:     2
+Label:      Importance of getting good job (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   o. Getting a good job
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40O. F1S40O is identical to F1D56O. However,
+the variable F1D56O contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                               3                0.02 
+2                   Somewhat important                                         41                0.25 
+3                   Very important                                            626                3.86 
+-9                  Missing                                                     4                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56P
+Position:   7068
+Length:     2
+Label:      Importance of being an active/informed citizen (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   p. Being an active and informed citizen
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40P. F1S40P is identical to F1D56P. However,
+the variable F1D56P contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                              61                0.38 
+2                   Somewhat important                                        264                1.63 
+3                   Very important                                            347                2.14 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56Q
+Position:   7070
+Length:     2
+Label:      Importance of supporting environmental causes (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   q. Supporting environmental causes
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40Q. F1S40Q is identical to F1D56Q. However,
+the variable F1D56Q contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                             124                0.77 
+2                   Somewhat important                                        339                2.09 
+3                   Very important                                            207                1.28 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-2                  Refused                                                     1                0.01 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D56R
+Position:   7072
+Length:     2
+Label:      Importance of being patriotic (DO)
+
+Description:
+   56. How important is each of the following to you in your life?
+   (MARK ONE RESPONSE ON EACH LINE)
+   (Not important; Somewhat important; Very important)
+   r. Being patriotic
+Note:   This is one of a series of items, a through r. This is the
+dropout version of F1S40R. F1S40R is identical to F1D56R. However,
+the variable F1D56R contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Not important                                             145                0.90 
+2                   Somewhat important                                        289                1.78 
+3                   Very important                                            229                1.41 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-2                  Refused                                                     1                0.01 
+-1                  Don't know                                                  8                0.05 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D57
+Position:   7074
+Length:     2
+Label:      How far in school respondent thinks will get (DO)
+
+Description:
+   57. As things stand now, how far in school do you think you will
+   get?
+   (MARK ONE RESPONSE)
+   Less than high school graduation
+   GED or other equivalency only
+   High school graduation only
+   Attend or complete a 1- or 2-year program in a community college or
+   vocational school
+   Attend college, but not complete a 4- or 5-year degree
+   Graduate from college (4- or 5-year degree)
+   Obtain a master's degree or equivalent
+   Obtain a Ph.D., M.D., or other advanced degree
+   Don't know
+Note:   This is the dropout version of F1S42. Unless otherwise noted
+below, F1S42 is identical to the F1D57. However, the variable F1D57
+contains only data collected from dropouts. Early graduate (F1E41)
+response options are different: 'Less than high school graduation' is
+not included.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Less than high school graduation                           11                0.07 
+2                   GED or other equivalency only                              94                0.58 
+3                   High school graduation only                                33                0.20 
+4                   Attend or complete 2-year college or sch                  152                0.94 
+5                   Attend college, 4-year degree incomplete                   18                0.11 
+6                   Graduate from college                                     105                0.65 
+7                   Obtain Master's degree or equivalent                       32                0.20 
+8                   Obtain PhD, MD, or other advanced degree                   21                0.13 
+9                   Don't know                                                206                1.27 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D58A
+Position:   7076
+Length:     2
+Label:      How far in school mother wants respondent to go (DO)
+
+Description:
+   58. How far in school do you think your mother and father want
+   you to go? BE SURE TO ANSWER BOTH A AND B BELOW.
+   Mother (or female guardian)
+   (MARK ONE)
+   Less than high school graduation
+   GED or other equivalency only
+   High school graduation only
+   Attend or complete a 1- or 2-year program in a community college or
+   vocational school
+   Attend college, but not complete a 4- or 5-year degree
+   Graduate from college (4- or 5-year degree)
+   Obtain a master's degree or equivalent
+   Obtain a Ph.D., M.D., or other advanced degree
+   Don't know
+   Does not apply
+Note:   This is one of a series of items, a through b. This is the
+dropout version of F1S43A. F1S43A is identical to F1D58A.
+However, the variable F1D58A contains only data collected from
+dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Less than high school graduation                           12                0.07 
+2                   GED or other equivalency only                              32                0.20 
+3                   High school graduation only                                64                0.40 
+4                   Attend or complete 2-year college or sch                   76                0.47 
+5                   Attend college, 4-year degree incomplete                   21                0.13 
+6                   Graduate from college                                     232                1.43 
+7                   Obtain Master's degree or equivalent                       57                0.35 
+8                   Obtain PhD, MD, or other advanced degree                   54                0.33 
+9                   Don't know                                                 88                0.54 
+-9                  Missing                                                     5                0.03 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                    32                0.20 
+-2                  Refused                                                     1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D58B
+Position:   7078
+Length:     2
+Label:      How far in school father wants respondent to go (DO)
+
+Description:
+   58. How far in school do you think your mother and father want
+   you to go? BE SURE TO ANSWER BOTH A AND B BELOW.
+   Father (or male guardian)
+   (MARK ONE)
+   Less than high school graduation
+   GED or other equivalency only
+   High school graduation only
+   Attend or complete a 1- or 2-year program in a community college or
+   vocational school
+   Attend college, but not complete a 4- or 5-year degree
+   Graduate from college (4- or 5-year degree)
+   Obtain a master's degree or equivalent
+   Obtain a Ph.D., M.D., or other advanced degree
+   Don't know
+   Does not apply
+Note:   This is one of a series of items, a through b. This is the
+dropout version of F1S43B. F1S43B is identical to F1D58B.
+However, the variable F1D58B contains only data collected from
+dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Less than high school graduation                            9                0.06 
+2                   GED or other equivalency only                              27                0.17 
+3                   High school graduation only                                52                0.32 
+4                   Attend or complete 2-year college or sch                   48                0.30 
+5                   Attend college, 4-year degree incomplete                   22                0.14 
+6                   Graduate from college                                     190                1.17 
+7                   Obtain Master's degree or equivalent                       51                0.31 
+8                   Obtain PhD, MD, or other advanced degree                   53                0.33 
+9                   Don't know                                                115                0.71 
+-9                  Missing                                                    15                0.09 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                    91                0.56 
+-2                  Refused                                                     1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D59
+Position:   7080
+Length:     2
+Label:      Number of jobs held since left high school (DO)
+
+Description:
+   59. How many jobs have you held since you last left high school?
+   (MARK ONE RESPONSE)
+   None (SKIP TO QUESTION 66 ON PAGE 21)
+   One (GO TO QUESTION 60)
+   Two (GO TO QUESTION 60)
+   Three (GO TO QUESTION 60)
+   Four (GO TO QUESTION 60)
+   Five or more (GO TO QUESTION 60)
+Note:   This item also appears on the early graduate (F1E49)
+questionnaire. However, the variable F1D59 contains only data
+collected from dropouts and the wording of the dropout item is
+different from that of the early graduate item. In the early
+graduate (F1E49) item, the phrase, 'since you last left' is instead
+replaced with 'since you left'.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None                                                      133                0.82 
+2                   One                                                       184                1.14 
+3                   Two                                                       173                1.07 
+4                   Three                                                     101                0.62 
+5                   Four                                                       40                0.25 
+6                   Five or more                                               40                0.25 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  1                0.01 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D60
+Position:   7082
+Length:     150
+Label:      Current/most recent job or occupation (DO) - restricted
+
+Description:
+   60. Write in the name of your current or most recent job. If you
+   have (or most recently had) two jobs at the same time, answer for
+   the job you had the longest.
+   Current or most recent job
+Available only on the restricted-use file.
+Note:   This item also appears on the early graduate (F1E50)
+questionnaire, which is identical. However, the variable F1D60
+contains only data collected from dropouts.
+Applies to: Respondents who have held a job since last leaving high
+school.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+Variable suppressed with -5 values on the public use file.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D61
+Position:   7232
+Length:     6
+Label:      Month and year started working at this job (DO)
+
+Description:
+   61. When did you start working at this job?
+   Month
+   January
+   February
+   March
+   April
+   May
+   June
+   July
+   August
+   September
+   October
+   November
+   December
+   Year
+   1997 or before
+   1998
+   1999
+   2000
+   2001
+   2002
+   2003
+   2004
+Note:   This item also appears on the early graduate (F1E51)
+questionnaire, which is identical. However, the variable F1D61
+contains only data collected from dropouts. Data provided in a single
+(yyyymm) format.
+Applies to: Respondents who have held a job since last leaving high
+school.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                    199700.00           200407.00           200305.58              118.37 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D62
+Position:   7238
+Length:     2
+Label:      Still have this job (DO)
+
+Description:
+   62. Do you still have this job?
+   Yes (SKIP TO QUESTION 64 ON PAGE 21)
+   No (GO TO QUESTION 63)
+Note:   This item also appears on the early graduate (F1E52)
+questionnaire, which is identical. However, the variable F1D62
+contains only data collected from dropouts.
+Applies to: Respondents who have held a job since last leaving high
+school.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        211                1.30 
+1                   Yes                                                       328                2.03 
+-9                  Missing                                                     2                0.01 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     8                0.05 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   133                0.82 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D63
+Position:   7240
+Length:     6
+Label:      Month and year left most recent job (DO)
+
+Description:
+   63. When did you leave this job?
+   Month
+   January
+   February
+   March
+   April
+   May
+   June
+   July
+   August
+   September
+   October
+   November
+   December
+   Year
+   2002
+   2003
+   2004
+Note:   This item also appears on the early graduate (F1E53)
+questionnaire, which is identical. However, the variable F1D63
+contains only data collected from dropouts. Data provided in a single
+(yyyymm) format.
+Applies to: Respondents who left their job since last leaving high
+school.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                    200200.00           200407.00           200362.80               53.47 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D64
+Position:   7246
+Length:     2
+Label:      Current/most recent pay per hour (DO)
+
+Description:
+   64. How much do you earn per hour currently, or did you earn just
+   before you left this job?
+   (MARK ONE RESPONSE)
+   Less than $5.15
+   $5.15 - $7.00
+   $7.01 - $9.00
+   $9.01 - $11.00
+   $11.01 - $13.00
+   $13.01 - $15.00
+   $15.01 - $17.00
+   $17.01 or more
+Note:   This item also appears on the early graduate (F1E54)
+questionnaire, which is identical. However, the variable F1D64
+contains only data collected from dropouts. Categories 7 and 8
+(greater than $15.00 per hour) were collapsed into category 6
+($13.01-$15.00) for disclosure avoidance purposes.
+Applies to: Respondents who have held a job since last leaving high
+school.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Less than $5.15                                            24                0.15 
+2                   $5.15-$7.00                                               230                1.42 
+3                   $7.01-$9.00                                               172                1.06 
+4                   $9.01-$11.00                                               63                0.39 
+5                   $11.01-$13.00                                              14                0.09 
+6                   $13.01-$15.00                                              21                0.13 
+-9                  Missing                                                     6                0.04 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     9                0.06 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   133                0.82 
+-1                  Don't know                                                 10                0.06 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D65
+Position:   7248
+Length:     2
+Label:      Number of hours/week usually worked at this job (DO)
+
+Description:
+   65. About how many hours a week did/do you usually work in this
+   job?
+   Hours per week
+Note:   This item also appears on the early graduate (F1E55)
+questionnaire, which is identical. However, the variable F1D65
+contains only data collected from dropouts. Values greater
+than 40 were set to 41.
+Applies to: Respondents who have held a job since last leaving high
+school.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                           Mean       Std Deviation 
+Category                            Min                 Max          Unweighted          Unweighted 
+------------------- ------------------- ------------------- ------------------- ------------------- 
+Continuous                         2.00               41.00               32.28               10.73 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D66
+Position:   7250
+Length:     150
+Label:      Occupation expects to have at age 30-verbatim (DO) - restricted
+
+Description:
+   66. Write in the name of the job or occupation that you expect or
+   plan to have at age 30.
+   Occupation at age 30
+Available only on the restricted-use file.
+Note:   This is the dropout version of F1S57. F1S57 is identical to
+F1D66. However, the variable F1D66 contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+Variable suppressed with -5 values on the public use file.
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D67
+Position:   7400
+Length:     2
+Label:      Education respondent thinks will be needed for job at age 30 (DO)
+
+Description:
+   67. How much education do you think you need to get the job you
+   expect or plan to have when you are 30 years old?
+   (MARK ONE RESPONSE)
+   Some high school
+   High school diploma or GED
+   Less than 2 years in a community college or vocational school
+   Completion of a 2-year program at a community college or vocational
+   school
+   Attend college, but not complete a 4- or 5- year degree
+   4- or 5-year college degree
+   Master's degree
+   Ph.D.
+   Professional degree (such as J.D. or M.D.)
+   Not planning to work at age 30
+Note:   This is the dropout version of F1S58. F1S58 is identical to
+F1D67. However, the variable F1D67 contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   Some high school                                           20                0.12 
+2                   High school diploma or GED                                 55                0.34 
+3                   Less than 2 yrs of 2-year college/school                   47                0.29 
+4                   Complete 2-year college/school                            103                0.64 
+5                   Attend college, 4-year degree incomplete                   28                0.17 
+6                   College degree                                             77                0.48 
+7                   Master's degree                                            41                0.25 
+8                   Ph.D.                                                      15                0.09 
+9                   Professional degree                                        13                0.08 
+-9                  Missing                                                    10                0.06 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     9                0.06 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-3                  Item legitimate skip/NA                                   258                1.59 
+-2                  Refused                                                     1                0.01 
+-1                  Don't know                                                  5                0.03 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D68
+Position:   7402
+Length:     2
+Label:      Performed unpaid volunteer/community service work (DO)
+
+Description:
+   68. During the past two years, have you performed any unpaid
+   volunteer or community service work (through such organizations as
+   youth groups, service clubs, church groups, school groups, or
+   social action groups)?
+   Yes
+   No
+Note:   This is the dropout version of F1S62. F1S62 is identical to
+F1D68. However, the variable F1D68 contains only data collected
+from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+0                   No                                                        474                2.93 
+1                   Yes                                                       193                1.19 
+-9                  Missing                                                     3                0.02 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     9                0.06 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  3                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D69A
+Position:   7404
+Length:     2
+Label:      How many friends dropped out of high school (DO)
+
+Description:
+   69. How many of your friends...
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None of them; A few of them; Some of them; Most of them; All of
+   them)
+   a. dropped out of high school without graduating?
+Note:   This is one of a series of items, a through d. This is the
+dropout version of F1S65A. F1S65A is identical to F1D69A. However,
+the variable F1D69A contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None of them                                              114                0.70 
+2                   A few of them                                             326                2.01 
+3                   Some of them                                              136                0.84 
+4                   Most of them                                               75                0.46 
+5                   All of them                                                10                0.06 
+-9                  Missing                                                     8                0.05 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     9                0.06 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                  4                0.02 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D69B
+Position:   7406
+Length:     2
+Label:      How many friends plan to have full-time job after high school (DO)
+
+Description:
+   69. How many of your friends...
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None of them; A few of them; Some of them; Most of them; All of
+   them)
+   b. plan to have a regular full-time job after high school?
+Note:   This is one of a series of items, a through d. This is the
+dropout version of F1S65B. F1S65B is identical to F1D69B. However,
+the variable F1D69B contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None of them                                               44                0.27 
+2                   A few of them                                             139                0.86 
+3                   Some of them                                              142                0.88 
+4                   Most of them                                              193                1.19 
+5                   All of them                                               131                0.81 
+-9                  Missing                                                     9                0.06 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     9                0.06 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                 15                0.09 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D69C
+Position:   7408
+Length:     2
+Label:      How many friends plan to attend 2-year community college (DO)
+
+Description:
+   69. How many of your friends...
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None of them; A few of them; Some of them; Most of them; All of
+   them)
+   c. plan to attend a two-year community college or technical
+   school?
+Note:   This is one of a series of items, a through d. This is the
+dropout version of F1S65C. F1S65C is identical to F1D69C. However,
+the variable F1D69C contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None of them                                              119                0.73 
+2                   A few of them                                             192                1.19 
+3                   Some of them                                              201                1.24 
+4                   Most of them                                               99                0.61 
+5                   All of them                                                26                0.16 
+-9                  Missing                                                    11                0.07 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     9                0.06 
+                    or breakoff
+-6                  Multiple response                                           1                0.01 
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                 24                0.15 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+
+
+File:       BYF3PSTSTU.PRI
+Name:       F1D69D
+Position:   7410
+Length:     2
+Label:      How many friends plan to attend 4-year college/university (DO)
+
+Description:
+   69. How many of your friends...
+   (MARK ONE RESPONSE ON EACH LINE)
+   (None of them; A few of them; Some of them; Most of them; All of
+   them)
+   d. plan to attend a four-year college or university?
+Note:   This is one of a series of items, a through d. This is the
+dropout version of F1S65D. F1S65D is identical to F1D69D. However,
+the variable F1D69D contains only data collected from dropouts.
+Applies to: All respondents.
+Source: ELS:2002 first follow-up Dropout questionnaire
+
+
+                                                                        Frequency             Percent 
+Category            Label                                              Unweighted          Unweighted 
+------------------- ----------------------------------------- ------------------- ------------------- 
+1                   None of them                                              170                1.05 
+2                   A few of them                                             193                1.19 
+3                   Some of them                                              157                0.97 
+4                   Most of them                                               87                0.54 
+5                   All of them                                                28                0.17 
+-9                  Missing                                                    13                0.08 
+-8                  Survey component legitimate skip/NA                    14,384               88.81 
+-7                  Not administered; abbreviated interview                     9                0.06 
+                    or breakoff
+-4                  Nonrespondent                                           1,131                6.98 
+-1                  Don't know                                                 25                0.15 
+TOTAL                                                                      16,197              100.00 
+
+
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Research question: Build a prediction model to find out key features of drop-out students in K-12. 
1. Description of data: 
   The data that I selected for my research question is Education Longitudinal Study of 2002 (ELS: 2000) provided from National Center for Education Statistics (NCES). ELS: 2000 is a nationally representative, longitudinal data of 10th graders in 2002 and 12th graders in 2004 who followed throughout the secondary and post-secondary years. It includes surveys from students, parents, Math and English teachers, and school administrators as well as student assessments in Math and English. High school transcripts are also available but restricted. NCES conducted a study in the beginning of 2002 for high school sophomores, first following up in 2004, second in 2006, and final in 2012 (NCES, n.d.). I chose this dataset since it was providing questions related to reasons for drop-out students. 183 variables were identified to be closely associated wi
